### PR TITLE
nullprojector added and tested on python

### DIFF
--- a/lanelet2_io/include/lanelet2_io/Projection.h
+++ b/lanelet2_io/include/lanelet2_io/Projection.h
@@ -70,6 +70,24 @@ class SphericalMercatorProjector : public Projector {
  private:
   static constexpr double EarthRadius{6378137.0};
 };
+
+
+/**
+ * @brief a null class to allow input points that are already in geo-spatial coordinates.
+ *
+ * It will not operate any convertion to local/utm/other coordinate system
+ */
+class NullProjector : public Projector {
+ public:
+  using Projector::Projector;
+  BasicPoint3d forward(const GPSPoint& p) const override {
+    return {p.lat, p.lon, p.ele};
+  }
+
+  GPSPoint reverse(const BasicPoint3d& p) const override {
+    return {p.x(), p.y(), p.z()};
+  }
+};
 }  // namespace projection
 
 using DefaultProjector = projection::SphericalMercatorProjector;

--- a/lanelet2_io/include/lanelet2_io/Projection.h
+++ b/lanelet2_io/include/lanelet2_io/Projection.h
@@ -21,7 +21,8 @@ struct Origin {
 class Projector {  // NOLINT
  public:
   using Ptr = std::shared_ptr<Projector>;
-  explicit Projector(Origin origin = Origin::defaultOrigin()) : origin_{origin} {}
+  explicit Projector(Origin origin = Origin::defaultOrigin(),
+              const std::string& pName = "") : origin_{origin}, name_{pName} {}
   Projector(Projector&& rhs) noexcept = default;
   Projector& operator=(Projector&& rhs) noexcept = default;
   Projector(const Projector& rhs) = default;
@@ -39,8 +40,12 @@ class Projector {  // NOLINT
   //! Obtain the internal origin
   const Origin& origin() const { return origin_; }
 
+  //! Get the name of the type of projector in use (internal use mainly)
+  const std::string & name() const { return name_;}
+
  private:
   Origin origin_;
+  std::string name_;
 };
 
 namespace projection {
@@ -53,6 +58,8 @@ namespace projection {
 class SphericalMercatorProjector : public Projector {
  public:
   using Projector::Projector;
+  explicit SphericalMercatorProjector(Origin origin = Origin::defaultOrigin()) :
+                    Projector(origin, "SphericalMercatorProjector") {}
   BasicPoint3d forward(const GPSPoint& p) const override {
     const auto scale = std::cos(origin().position.lat * M_PI / 180.0);
     const double x{scale * p.lon * M_PI * EarthRadius / 180.0};
@@ -80,6 +87,8 @@ class SphericalMercatorProjector : public Projector {
 class NullProjector : public Projector {
  public:
   using Projector::Projector;
+  explicit NullProjector(Origin origin = Origin::defaultOrigin()) :
+                  Projector(origin, "NullProjector") {}
   BasicPoint3d forward(const GPSPoint& p) const override {
     return {p.lat, p.lon, p.ele};
   }
@@ -88,6 +97,8 @@ class NullProjector : public Projector {
     return {p.x(), p.y(), p.z()};
   }
 };
+
+
 }  // namespace projection
 
 using DefaultProjector = projection::SphericalMercatorProjector;

--- a/lanelet2_io/include/lanelet2_io/io_handlers/IoHandler.h
+++ b/lanelet2_io/include/lanelet2_io/io_handlers/IoHandler.h
@@ -2,6 +2,7 @@
 #include <memory>
 #include "../Configuration.h"
 #include "../Projection.h"
+#include <iostream>
 
 namespace lanelet {
 using ErrorMessages = std::vector<std::string>;
@@ -31,7 +32,8 @@ class IOHandler {  // NOLINT
   static constexpr const char* name() { return ""; }
 
   const Projector& projector() const {
-    if (projector_->origin().isDefault) {
+    if (projector_->origin().isDefault
+        && projector_->name() != "NullProjector") {
       handleDefaultProjector();
     }
     return *projector_;

--- a/lanelet2_projection/README.md
+++ b/lanelet2_projection/README.md
@@ -13,3 +13,4 @@ For more details, read [here](doc/Map_Projections_Coordinate_Systems.md).
 
  - `UTM.h`: WGS84 (for storage in .osm files) <-> UTM (internal processing) (wrapper of https://sourceforge.net/projects/geographiclib/). This projection has the advantage of being very precise, but all points in the map must fit into one UTM Tile. If points exceed a 100km margin, the map can not be loaded.
  - `Mercator.h`: WGS84 (for storage in .osm files) <-> Local  Mercator as in [liblanelet](https://github.com/phbender/liblanelet/blob/master/Commons/mercator.hpp). Approximates the earth 
+  - `NullProjector`: to use into lanelet_io.write(file, map, projector) when you are dumping to file a map that is already in geo-spatial coordinates and needs no further transformation.

--- a/lanelet2_projection/include/lanelet2_projection/Mercator.h
+++ b/lanelet2_projection/include/lanelet2_projection/Mercator.h
@@ -9,7 +9,7 @@ namespace projection {
 class Mercator : public Projector {
  public:
   explicit Mercator(const Origin& origin = Origin::defaultOrigin())
-      : Projector(origin), offset_{rawForward(origin.position)} {}
+      : Projector(origin, "Mercator"), offset_{rawForward(origin.position)} {}
 
   BasicPoint3d forward(const GPSPoint& pGps) const override { return rawForward(pGps) - offset_; }
   GPSPoint reverse(const BasicPoint3d& p) const override { return rawReverse(p + offset_); }

--- a/lanelet2_projection/src/UTM.cpp
+++ b/lanelet2_projection/src/UTM.cpp
@@ -5,7 +5,7 @@ namespace lanelet {
 namespace projection {
 
 UtmProjector::UtmProjector(Origin origin, const bool useOffset, const bool throwInPaddingArea)
-    : Projector(origin), useOffset_{useOffset}, throwInPaddingArea_{throwInPaddingArea} {
+    : Projector(origin, "UtmProjector"), useOffset_{useOffset}, throwInPaddingArea_{throwInPaddingArea} {
   double x, y;
   GeographicLib::UTMUPS::Forward(this->origin().position.lat, this->origin().position.lon, zone_,
                                  isInNorthernHemisphere_, x, y);

--- a/lanelet2_python/python_api/projection.cpp
+++ b/lanelet2_python/python_api/projection.cpp
@@ -10,10 +10,10 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
       .def("forward", &Projector::forward, "Convert lat/lon into x/y")
       .def("reverse", &Projector::reverse, "Convert x/y into lat/lon");
   class_<projection::NullProjector, std::shared_ptr<projection::NullProjector>,
-             bases<Projector>>("NullProjector", init<Origin>("origin"));
+         bases<Projector>>("NullProjector", init<optional<Origin>>("origin"));
   class_<projection::SphericalMercatorProjector, std::shared_ptr<projection::SphericalMercatorProjector>,  // NOLINT
-         bases<Projector>>("MercatorProjector", init<Origin>("origin"));
-  class_<projection::UtmProjector, std::shared_ptr<projection::UtmProjector>, bases<Projector>>("UtmProjector",
-                                                                                                init<Origin>("origin"))
-      .def(init<Origin, bool, bool>("UtmProjector(origin, useOffset, throwInPaddingArea)"));
+          bases<Projector>>("MercatorProjector", init<Origin>("origin"));
+  class_<projection::UtmProjector, std::shared_ptr<projection::UtmProjector>,
+          bases<Projector>>("UtmProjector", init<Origin>("origin"))
+          .def(init<Origin, bool, bool>("UtmProjector(origin, useOffset, throwInPaddingArea)"));
 }

--- a/lanelet2_python/python_api/projection.cpp
+++ b/lanelet2_python/python_api/projection.cpp
@@ -9,6 +9,8 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
       "Projector", "Projects point from lat/lon to x/y and back", no_init)
       .def("forward", &Projector::forward, "Convert lat/lon into x/y")
       .def("reverse", &Projector::reverse, "Convert x/y into lat/lon");
+  class_<projection::NullProjector, std::shared_ptr<projection::NullProjector>,
+             bases<Projector>>("NullProjector", init<Origin>("origin"));
   class_<projection::SphericalMercatorProjector, std::shared_ptr<projection::SphericalMercatorProjector>,  // NOLINT
          bases<Projector>>("MercatorProjector", init<Origin>("origin"));
   class_<projection::UtmProjector, std::shared_ptr<projection::UtmProjector>, bases<Projector>>("UtmProjector",


### PR DESCRIPTION
My data has geo-spatial coordinates already provided. So I need to be able to dump the OSM without making any projection :) 

tested with this code 

```
from lanelet2.core import *
from lanelet2.projection import *
from lanelet2 import io
import os

lmap = LaneletMap()
segment = [(lat, lng, alt), (lat, lng, alt), ... ]
lb = LineString3d(getId(), [Point3d(getId(), pt[0], pt[1], pt[2]) for pt in segment])
am = AttributeMap({"type": "lanelet"})
llet = Lanelet(getId(), lb, lb, am)
lmap.add(llet)

proj = NullProjector(io.Origin(mylat, mylng))
pfile = os.path.join(os.path.dirname(os.path.abspath("")), "output.osm")
io.write(pfile, lmap, proj)

```