### PR TITLE
Removing auto-deps CMake script from mrt_cmake_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 *.pyc
 setup.py
 CMakeLists.txt.user
-
+*.osm
+*.bin

--- a/lanelet2_core/CMakeLists.txt
+++ b/lanelet2_core/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(mrt_cmake_modules REQUIRED)
 find_package(catkin REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED)
+find_package(Threads REQUIRED)
 
 # Mark files or folders for display in IDEs
 mrt_add_to_ide(README.md .gitlab-ci.yml)
@@ -58,7 +59,7 @@ endif()
 # DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
   INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIR}
-  LIBRARIES ${LIBRARY_NAME}
+  LIBRARIES ${LIBRARY_NAME} ${CMAKE_THREAD_LIBS_INIT}
   CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
 )
 
@@ -76,12 +77,7 @@ include_directories(
 mrt_add_library(${PROJECT_NAME}
   INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
   SOURCES ${PROJECT_SOURCE_FILES_SRC}
-)
-
-target_link_libraries(
-  ${PROJECT_NAME}
-  ${Boost_LIBRARIES}
-  ${catkin_LIBRARIES}
+  LIBRARIES ${Boost_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT} ${catkin_LIBRARIES}
 )
 
 #############
@@ -95,6 +91,9 @@ mrt_install(PROGRAMS scripts FILES res data doc)
 #############
 # Add test targets for cpp and python tests
 if (CATKIN_ENABLE_TESTING)
-  mrt_add_tests(test)
+  mrt_add_tests(
+    test
+    LIBRARIES ${CMAKE_THREAD_LIBS_INIT}
+  )
   mrt_add_nosetests(test)
 endif()

--- a/lanelet2_core/CMakeLists.txt
+++ b/lanelet2_core/CMakeLists.txt
@@ -6,7 +6,9 @@ set(MRT_COTIRE_ENABLED 1)
 set (COTIRE_MINIMUM_NUMBER_OF_TARGET_SOURCES 1)
 set (COTIRE_MAXIMUM_NUMBER_OF_UNITY_INCLUDES "-j")
 
-add_definitions(-std=c++14)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
 ###################
 ## find packages ##

--- a/lanelet2_core/CMakeLists.txt
+++ b/lanelet2_core/CMakeLists.txt
@@ -12,8 +12,6 @@ add_definitions(-std=c++14)
 ## find packages ##
 ###################
 find_package(mrt_cmake_modules REQUIRED)
-
-# Manually resolve removed dependend packages
 find_package(catkin REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED)

--- a/lanelet2_core/CMakeLists.txt
+++ b/lanelet2_core/CMakeLists.txt
@@ -57,8 +57,8 @@ endif()
 # CATKIN_DEPENDS: catkin_packages dependent projects also need
 # DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-  INCLUDE_DIRS include ${mrt_EXPORT_INCLUDE_DIRS}
-  LIBRARIES ${LIBRARY_NAME} ${mrt_EXPORT_LIBRARIES}
+  INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIR}
+  LIBRARIES ${LIBRARY_NAME}
   CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
 )
 

--- a/lanelet2_core/CMakeLists.txt
+++ b/lanelet2_core/CMakeLists.txt
@@ -6,20 +6,17 @@ set(MRT_COTIRE_ENABLED 1)
 set (COTIRE_MINIMUM_NUMBER_OF_TARGET_SOURCES 1)
 set (COTIRE_MAXIMUM_NUMBER_OF_UNITY_INCLUDES "-j")
 
+add_definitions(-std=c++14)
+
 ###################
 ## find packages ##
 ###################
 find_package(mrt_cmake_modules REQUIRED)
-include(UseMrtStdCompilerFlags)
-include(UseMrtAutoTarget)
-
-include(GatherDeps)
-# Remove libs which cannot be found automatically
-#list(REMOVE_ITEM DEPENDEND_PACKAGES <package name 1> <package name 2> ...)
-find_package(AutoDeps REQUIRED COMPONENTS ${DEPENDEND_PACKAGES})
 
 # Manually resolve removed dependend packages
-#find_package(...)
+find_package(catkin REQUIRED)
+find_package(Eigen3 REQUIRED)
+find_package(Boost REQUIRED)
 
 # Mark files or folders for display in IDEs
 mrt_add_to_ide(README.md .gitlab-ci.yml)
@@ -34,10 +31,11 @@ mrt_python_module_setup()
 
 file(GLOB PROJECT_PYTHON_SOURCE_FILES_SRC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "python_api/*.cpp")
 if (PROJECT_PYTHON_SOURCE_FILES_SRC)
-    # Add a cpp-python api library. Make sure there are no name collisions with python modules in this project
-    mrt_add_python_api( ${PROJECT_NAME}
-        FILES ${PROJECT_PYTHON_SOURCE_FILES_SRC}
-        )
+  # Add a cpp-python api library. Make sure there are no name collisions with python modules in this project
+  mrt_add_python_api(
+    ${PROJECT_NAME}
+    FILES ${PROJECT_PYTHON_SOURCE_FILES_SRC}
+  )
 endif()
 
 ############################
@@ -48,7 +46,7 @@ file(GLOB PROJECT_SOURCE_FILES_INC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "src/*.h
 file(GLOB PROJECT_SOURCE_FILES_SRC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "src/*.cpp")
 
 if (PROJECT_SOURCE_FILES_SRC)
-    set(LIBRARY_NAME ${PROJECT_NAME})
+  set(LIBRARY_NAME ${PROJECT_NAME})
 endif()
 
 ###################################
@@ -61,30 +59,32 @@ endif()
 # CATKIN_DEPENDS: catkin_packages dependent projects also need
 # DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-    INCLUDE_DIRS include ${mrt_EXPORT_INCLUDE_DIRS}
-    LIBRARIES ${LIBRARY_NAME} ${mrt_EXPORT_LIBRARIES}
-    CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
-    )
+  INCLUDE_DIRS include ${mrt_EXPORT_INCLUDE_DIRS}
+  LIBRARIES ${LIBRARY_NAME} ${mrt_EXPORT_LIBRARIES}
+  CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
+)
 
 ###########
 ## Build ##
 ###########
 # Add include and library directories
 include_directories(
-    include/${PROJECT_NAME}
-    ${mrt_INCLUDE_DIRS}
-    ${catkin_INCLUDE_DIRS}
-    )
-
-link_directories(
-    ${mrt_LIBRARY_DIRS}
-    )
+  include/${PROJECT_NAME}
+  ${EIGEN3_INCLUDE_DIR}
+  ${catkin_INCLUDE_DIRS}
+)
 
 # Declare a cpp library
 mrt_add_library(${PROJECT_NAME}
-    INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
-    SOURCES ${PROJECT_SOURCE_FILES_SRC}
-    )
+  INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
+  SOURCES ${PROJECT_SOURCE_FILES_SRC}
+)
+
+target_link_libraries(
+  ${PROJECT_NAME}
+  ${Boost_LIBRARIES}
+  ${catkin_LIBRARIES}
+)
 
 #############
 ## Install ##
@@ -97,6 +97,6 @@ mrt_install(PROGRAMS scripts FILES res data doc)
 #############
 # Add test targets for cpp and python tests
 if (CATKIN_ENABLE_TESTING)
-    mrt_add_tests(test)
-    mrt_add_nosetests(test)
+  mrt_add_tests(test)
+  mrt_add_nosetests(test)
 endif()

--- a/lanelet2_examples/CMakeLists.txt
+++ b/lanelet2_examples/CMakeLists.txt
@@ -3,7 +3,9 @@ set(MRT_PKG_VERSION 2.2.1)
 cmake_minimum_required(VERSION 2.8.12)
 project(lanelet2_examples)
 
-add_definitions(-std=c++14)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
 ###################
 ## find packages ##

--- a/lanelet2_examples/CMakeLists.txt
+++ b/lanelet2_examples/CMakeLists.txt
@@ -3,20 +3,21 @@ set(MRT_PKG_VERSION 2.2.1)
 cmake_minimum_required(VERSION 2.8.12)
 project(lanelet2_examples)
 
+add_definitions(-std=c++14)
+
 ###################
 ## find packages ##
 ###################
+find_package(
+  catkin REQUIRED COMPONENTS
+  lanelet2_core
+  lanelet2_io
+  lanelet2_traffic_rules
+  lanelet2_routing
+  lanelet2_projection
+)
 find_package(mrt_cmake_modules REQUIRED)
-include(UseMrtStdCompilerFlags)
-include(UseMrtAutoTarget)
-
-include(GatherDeps)
-# Remove libs which cannot be found automatically
-#list(REMOVE_ITEM DEPENDEND_PACKAGES <package name 1> <package name 2> ...)
-find_package(AutoDeps REQUIRED COMPONENTS ${DEPENDEND_PACKAGES})
-
-# Manually resolve removed dependend packages
-#find_package(...)
+find_package(Eigen3 REQUIRED)
 
 # Mark files or folders for display in IDEs
 mrt_add_to_ide(README.md .gitlab-ci.yml)
@@ -33,31 +34,26 @@ mrt_python_module_setup()
 ###################################
 ## catkin specific configuration ##
 ###################################
-catkin_package(
-    )
+catkin_package()
 
 ###########
 ## Build ##
 ###########
 # Add include and library directories
 include_directories(
-    ${mrt_INCLUDE_DIRS}
-    ${catkin_INCLUDE_DIRS}
-    )
-
-link_directories(
-    ${mrt_LIBRARY_DIRS}
-    )
+  ${EIGEN3_INCLUDE_DIR}
+  ${catkin_INCLUDE_DIRS}
+)
 
 glob_folders(SRC_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/src")
 if (SRC_DIRECTORIES)
-    # Found subfolders, add executable for each subfolder
-    foreach(SRC_DIR ${SRC_DIRECTORIES})
-        mrt_add_executable(${SRC_DIR} FOLDER "src/${SRC_DIR}")
-    endforeach()
+  # Found subfolders, add executable for each subfolder
+  foreach(SRC_DIR ${SRC_DIRECTORIES})
+    mrt_add_executable(${SRC_DIR} FOLDER "src/${SRC_DIR}")
+  endforeach()
 else()
-    # No subfolder found, add executable and python modules for src folder
-    mrt_add_executable(${PROJECT_NAME} FOLDER "src")
+  # No subfolder found, add executable and python modules for src folder
+  mrt_add_executable(${PROJECT_NAME} FOLDER "src")
 endif()
 
 #############
@@ -71,6 +67,6 @@ mrt_install(PROGRAMS scripts FILES res data)
 #############
 # Add test targets for cpp and python tests
 if (CATKIN_ENABLE_TESTING)
-    mrt_add_tests(test)
-    mrt_add_nosetests(test)
+  mrt_add_tests(test)
+  mrt_add_nosetests(test)
 endif()

--- a/lanelet2_examples/CMakeLists.txt
+++ b/lanelet2_examples/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(
   catkin REQUIRED COMPONENTS
   lanelet2_core
   lanelet2_io
+  lanelet2_python
   lanelet2_traffic_rules
   lanelet2_routing
   lanelet2_projection

--- a/lanelet2_io/CMakeLists.txt
+++ b/lanelet2_io/CMakeLists.txt
@@ -3,20 +3,16 @@ set(MRT_PKG_VERSION 2.2.1)
 cmake_minimum_required(VERSION 2.8.12)
 project(lanelet2_io)
 
+add_definitions(-std=c++14)
+
 ###################
 ## find packages ##
 ###################
+find_package(
+  catkin REQUIRED COMPONENTS
+  lanelet2_core
+)
 find_package(mrt_cmake_modules REQUIRED)
-include(UseMrtStdCompilerFlags)
-include(UseMrtAutoTarget)
-
-include(GatherDeps)
-# Remove libs which cannot be found automatically
-#list(REMOVE_ITEM DEPENDEND_PACKAGES <package name 1> <package name 2> ...)
-find_package(AutoDeps REQUIRED COMPONENTS ${DEPENDEND_PACKAGES})
-
-# Manually resolve removed dependend packages
-#find_package(...)
 
 # Mark files or folders for display in IDEs
 mrt_add_to_ide(README.md .gitlab-ci.yml)
@@ -30,10 +26,11 @@ mrt_python_module_setup()
 
 file(GLOB PROJECT_PYTHON_SOURCE_FILES_SRC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "python_api/*.cpp")
 if (PROJECT_PYTHON_SOURCE_FILES_SRC)
-    # Add a cpp-python api library. Make sure there are no name collisions with python modules in this project
-    mrt_add_python_api( ${PROJECT_NAME}
-        FILES ${PROJECT_PYTHON_SOURCE_FILES_SRC}
-        )
+  # Add a cpp-python api library. Make sure there are no name collisions with python modules in this project
+  mrt_add_python_api(
+    ${PROJECT_NAME}
+    FILES ${PROJECT_PYTHON_SOURCE_FILES_SRC}
+  )
 endif()
 
 ############################
@@ -44,7 +41,7 @@ file(GLOB PROJECT_SOURCE_FILES_INC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "src/*.h
 file(GLOB PROJECT_SOURCE_FILES_SRC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "src/*.cpp")
 
 if (PROJECT_SOURCE_FILES_SRC)
-    set(LIBRARY_NAME ${PROJECT_NAME})
+  set(LIBRARY_NAME ${PROJECT_NAME})
 endif()
 
 ###################################
@@ -57,30 +54,26 @@ endif()
 # CATKIN_DEPENDS: catkin_packages dependent projects also need
 # DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-    INCLUDE_DIRS include ${mrt_EXPORT_INCLUDE_DIRS}
-    LIBRARIES ${LIBRARY_NAME} ${mrt_EXPORT_LIBRARIES}
-    CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
-    )
+  INCLUDE_DIRS include
+  LIBRARIES ${LIBRARY_NAME}
+  CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
+)
 
 ###########
 ## Build ##
 ###########
 # Add include and library directories
 include_directories(
-    include/${PROJECT_NAME}
-    ${mrt_INCLUDE_DIRS}
-    ${catkin_INCLUDE_DIRS}
-    )
-
-link_directories(
-    ${mrt_LIBRARY_DIRS}
-    )
+  include/${PROJECT_NAME}
+  ${catkin_INCLUDE_DIRS}
+)
 
 # Declare a cpp library
-mrt_add_library(${PROJECT_NAME}
-    INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
-    SOURCES ${PROJECT_SOURCE_FILES_SRC}
-    )
+mrt_add_library(
+  ${PROJECT_NAME}
+  INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
+  SOURCES ${PROJECT_SOURCE_FILES_SRC}
+)
 
 #############
 ## Install ##
@@ -93,6 +86,6 @@ mrt_install(PROGRAMS scripts FILES res data)
 #############
 # Add test targets for cpp and python tests
 if (CATKIN_ENABLE_TESTING)
-    mrt_add_tests(test)
-    mrt_add_nosetests(test)
+  mrt_add_tests(test)
+  mrt_add_nosetests(test)
 endif()

--- a/lanelet2_io/CMakeLists.txt
+++ b/lanelet2_io/CMakeLists.txt
@@ -3,7 +3,9 @@ set(MRT_PKG_VERSION 2.2.1)
 cmake_minimum_required(VERSION 2.8.12)
 project(lanelet2_io)
 
-add_definitions(-std=c++14)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
 ###################
 ## find packages ##

--- a/lanelet2_io/CMakeLists.txt
+++ b/lanelet2_io/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${LIBRARY_NAME}
-  CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
+  CATKIN_DEPENDS lanelet2_core
 )
 
 ###########

--- a/lanelet2_io/CMakeLists.txt
+++ b/lanelet2_io/CMakeLists.txt
@@ -13,6 +13,14 @@ find_package(
   lanelet2_core
 )
 find_package(mrt_cmake_modules REQUIRED)
+find_package(
+  Boost REQUIRED COMPONENTS
+  filesystem
+  program_options
+  serialization
+  system
+)
+find_package(pugixml REQUIRED)
 
 # Mark files or folders for display in IDEs
 mrt_add_to_ide(README.md .gitlab-ci.yml)
@@ -54,9 +62,10 @@ endif()
 # CATKIN_DEPENDS: catkin_packages dependent projects also need
 # DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES ${LIBRARY_NAME}
+  INCLUDE_DIRS include ${PUGIXML_INCLUDE_DIRS}
+  LIBRARIES ${LIBRARY_NAME} ${PUGIXML_LIBRARIES}
   CATKIN_DEPENDS lanelet2_core
+  DEPENDS Boost
 )
 
 ###########

--- a/lanelet2_io/CMakeLists.txt
+++ b/lanelet2_io/CMakeLists.txt
@@ -74,14 +74,16 @@ catkin_package(
 # Add include and library directories
 include_directories(
   include/${PROJECT_NAME}
+  ${PUGIXML_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
 )
 
 # Declare a cpp library
 mrt_add_library(
   ${PROJECT_NAME}
-  INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
+  INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} ${PUGIXML_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS}
   SOURCES ${PROJECT_SOURCE_FILES_SRC}
+  LIBRARIES ${PUGIXML_LIBRARIES} ${Boost_LIBRARIES}
 )
 
 #############
@@ -95,6 +97,9 @@ mrt_install(PROGRAMS scripts FILES res data)
 #############
 # Add test targets for cpp and python tests
 if (CATKIN_ENABLE_TESTING)
-  mrt_add_tests(test)
+  mrt_add_tests(
+    test
+    LIBRARIES ${PUGIXML_LIBRARIES} ${Boost_LIBRARIES}
+  )
   mrt_add_nosetests(test)
 endif()

--- a/lanelet2_io/test/TestBinHandler.cpp
+++ b/lanelet2_io/test/TestBinHandler.cpp
@@ -1,6 +1,7 @@
 #include <io_handlers/Serialize.h>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
+#include <boost/filesystem.hpp>
 #include <cstdio>
 #include <fstream>
 #include "Io.h"
@@ -8,6 +9,7 @@
 #include "gtest/gtest.h"
 
 using namespace lanelet;
+namespace fs = boost::filesystem;
 
 struct MyStuff {
   int i{};
@@ -97,7 +99,7 @@ TEST_F(SerializeTest, LaneletMap) {  // NOLINT
 }
 
 TEST(BinHandler, extension) {  // NOLINT
-  std::string filename = std::tmpnam(nullptr) + std::string(".bin");
+  std::string filename = fs::unique_path().string() + std::string(".bin");
   auto map = std::make_shared<lanelet::LaneletMap>();
   lanelet::write(filename, *map);
 
@@ -105,7 +107,7 @@ TEST(BinHandler, extension) {  // NOLINT
 }
 
 TEST(BinHandler, explicitIO) {  // NOLINT
-  std::string filename = std::tmpnam(nullptr) + std::string(".bin");
+  std::string filename = fs::unique_path().string() + std::string(".bin");
   auto map = std::make_shared<lanelet::LaneletMap>();
   lanelet::write(filename, *map, "bin_handler");
 

--- a/lanelet2_io/test/TestLanelet2Io.cpp
+++ b/lanelet2_io/test/TestLanelet2Io.cpp
@@ -1,7 +1,10 @@
 #include "gtest/gtest.h"
 
+#include "boost/filesystem.hpp"
 #include "Exceptions.h"
 #include "Io.h"
+
+namespace fs = boost::filesystem;
 
 TEST(lanelet2_io, registryTest) {  // NOLINT
   auto parseExtensions = lanelet::supportedParserExtensions();
@@ -14,7 +17,7 @@ TEST(lanelet2_io, registryTest) {  // NOLINT
 }
 
 TEST(lanelet2_io, exceptionTest) {  // NOLINT
-  auto nonsenseExtension = std::string(std::tmpnam(nullptr)) + ".unsupported_extension";
+  auto nonsenseExtension = std::string(fs::unique_path().string()) + ".unsupported_extension";
   std::FILE* tmpf = std::fopen(nonsenseExtension.c_str(), "wb+");
   EXPECT_THROW(lanelet::load(nonsenseExtension), lanelet::UnsupportedExtensionError);                        // NOLINT
   EXPECT_THROW(lanelet::load(nonsenseExtension, "nonexisting_parser"), lanelet::UnsupportedIOHandlerError);  // NOLINT

--- a/lanelet2_io/test/TestOsmHandler.cpp
+++ b/lanelet2_io/test/TestOsmHandler.cpp
@@ -1,12 +1,14 @@
 #include <gtest/gtest.h>
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/primitives/BasicRegulatoryElements.h>
+#include <boost/filesystem.hpp>
 #include <cstdio>
 #include "Io.h"
 #include "TestSetup.h"
 #include "io_handlers/OsmHandler.h"
 
 using namespace lanelet;
+namespace fs = boost::filesystem;
 
 template <typename T, typename TT>
 T writeAndLoad(const T& value, TT(LaneletMap::*layer)) {
@@ -104,7 +106,7 @@ TEST(OsmHandler, writeMapWithLaneletAndAreaToFile) {  // NOLINT
   auto ll = test_setup::setUpLanelet(num);
   map->add(ar);
   map->add(ll);
-  auto filename = std::string(std::tmpnam(nullptr)) + ".osm";  // NOLINT
+  auto filename = std::string(fs::unique_path().string()) + ".osm";  // NOLINT
   Origin origin({49, 8.4, 0});
   write(filename, *map, origin);
   EXPECT_NO_THROW(load(filename, origin));  // NOLINT

--- a/lanelet2_io/test/TestSimpleUsage.cpp
+++ b/lanelet2_io/test/TestSimpleUsage.cpp
@@ -1,6 +1,9 @@
 #include "gtest/gtest.h"
 
+#include "boost/filesystem.hpp"
 #include "Io.h"
+
+namespace fs = boost::filesystem;
 
 TEST(lanelet2_io, exampleUsage) {  // NOLINT
   using namespace lanelet;
@@ -8,7 +11,7 @@ TEST(lanelet2_io, exampleUsage) {  // NOLINT
   std::string filenameIn = "../../lanelet2_maps/res/mapping_example.osm";
   LaneletMapPtr laneletMap = lanelet::load(filenameIn, origin);
 
-  std::string filenameOut = std::string(std::tmpnam(nullptr)) + ".osm";  // NOLINT
+  std::string filenameOut = std::string(fs::unique_path().string()) + ".osm";  // NOLINT
   lanelet::write(filenameOut, *laneletMap, origin);
   LaneletMapPtr laneletMapAgain = lanelet::load(filenameOut, origin);
 }

--- a/lanelet2_maps/CMakeLists.txt
+++ b/lanelet2_maps/CMakeLists.txt
@@ -3,6 +3,10 @@ set(MRT_PKG_VERSION 2.2.1)
 cmake_minimum_required(VERSION 2.8.12)
 project(lanelet2_maps)
 
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
 ###################
 ## find packages ##
 ###################

--- a/lanelet2_maps/CMakeLists.txt
+++ b/lanelet2_maps/CMakeLists.txt
@@ -6,21 +6,14 @@ project(lanelet2_maps)
 ###################
 ## find packages ##
 ###################
+find_package(
+  catkin REQUIRED COMPONENTS
+  lanelet2_core
+)
 find_package(mrt_cmake_modules REQUIRED)
-include(UseMrtStdCompilerFlags)
-include(UseMrtAutoTarget)
-
-include(GatherDeps)
-# Remove libs which cannot be found automatically
-#list(REMOVE_ITEM DEPENDEND_PACKAGES <package name 1> <package name 2> ...)
-find_package(AutoDeps REQUIRED COMPONENTS ${DEPENDEND_PACKAGES})
-
-# Manually resolve removed dependend packages
-#find_package(...)
 
 # Mark files or folders for display in IDEs
 mrt_add_to_ide(README.md .gitlab-ci.yml)
-
 
 ########################
 ## add python modules ##
@@ -30,10 +23,11 @@ mrt_python_module_setup()
 
 file(GLOB PROJECT_PYTHON_SOURCE_FILES_SRC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "python_api/*.cpp")
 if (PROJECT_PYTHON_SOURCE_FILES_SRC)
-    # Add a cpp-python api library. Make sure there are no name collisions with python modules in this project
-    mrt_add_python_api( ${PROJECT_NAME}
-        FILES ${PROJECT_PYTHON_SOURCE_FILES_SRC}
-        )
+  # Add a cpp-python api library. Make sure there are no name collisions with python modules in this project
+  mrt_add_python_api(
+    ${PROJECT_NAME}
+    FILES ${PROJECT_PYTHON_SOURCE_FILES_SRC}
+  )
 endif()
 
 ############################
@@ -44,7 +38,7 @@ file(GLOB PROJECT_SOURCE_FILES_INC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "src/*.h
 file(GLOB PROJECT_SOURCE_FILES_SRC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "src/*.cpp")
 
 if (PROJECT_SOURCE_FILES_SRC)
-    set(LIBRARY_NAME ${PROJECT_NAME})
+  set(LIBRARY_NAME ${PROJECT_NAME})
 endif()
 
 ###################################
@@ -57,30 +51,25 @@ endif()
 # CATKIN_DEPENDS: catkin_packages dependent projects also need
 # DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-    INCLUDE_DIRS include ${mrt_EXPORT_INCLUDE_DIRS}
-    LIBRARIES ${LIBRARY_NAME} ${mrt_EXPORT_LIBRARIES}
-    CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
-    )
+  INCLUDE_DIRS include
+  LIBRARIES ${LIBRARY_NAME}
+  CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
+)
 
 ###########
 ## Build ##
 ###########
 # Add include and library directories
 include_directories(
-    include/${PROJECT_NAME}
-    ${mrt_INCLUDE_DIRS}
-    ${catkin_INCLUDE_DIRS}
-    )
-
-link_directories(
-    ${mrt_LIBRARY_DIRS}
-    )
+  include/${PROJECT_NAME}
+  ${catkin_INCLUDE_DIRS}
+)
 
 # Declare a cpp library
 mrt_add_library(${PROJECT_NAME}
-    INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
-    SOURCES ${PROJECT_SOURCE_FILES_SRC}
-    )
+  INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
+  SOURCES ${PROJECT_SOURCE_FILES_SRC}
+)
 
 #############
 ## Install ##
@@ -93,6 +82,6 @@ mrt_install(PROGRAMS scripts FILES res data josm)
 #############
 # Add test targets for cpp and python tests
 if (CATKIN_ENABLE_TESTING)
-    mrt_add_tests(test)
-    mrt_add_nosetests(test)
+  mrt_add_tests(test)
+  mrt_add_nosetests(test)
 endif()

--- a/lanelet2_projection/CMakeLists.txt
+++ b/lanelet2_projection/CMakeLists.txt
@@ -64,6 +64,7 @@ catkin_package(
 # Add include and library directories
 include_directories(
   include/${PROJECT_NAME}
+  ${GeographicLib_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
 )
 
@@ -71,6 +72,7 @@ include_directories(
 mrt_add_library(${PROJECT_NAME}
   INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
   SOURCES ${PROJECT_SOURCE_FILES_SRC}
+  LIBRARIES ${GeographicLib_LIBRARIES}
 )
 
 #############

--- a/lanelet2_projection/CMakeLists.txt
+++ b/lanelet2_projection/CMakeLists.txt
@@ -3,6 +3,10 @@ set(MRT_PKG_VERSION 2.2.1)
 cmake_minimum_required(VERSION 2.8.12)
 project(lanelet2_projection)
 
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
 ###################
 ## find packages ##
 ###################

--- a/lanelet2_projection/CMakeLists.txt
+++ b/lanelet2_projection/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(
   lanelet2_io
 )
 find_package(mrt_cmake_modules REQUIRED)
+find_package(GeographicLib REQUIRED)
 
 # Mark files or folders for display in IDEs
 mrt_add_to_ide(README.md .gitlab-ci.yml)
@@ -52,8 +53,8 @@ endif()
 # CATKIN_DEPENDS: catkin_packages dependent projects also need
 # DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES ${LIBRARY_NAME}
+  INCLUDE_DIRS include ${GeographicLib_INCLUDE_DIRS}
+  LIBRARIES ${LIBRARY_NAME} ${GeographicLib_LIBRARIES}
   CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
 )
 

--- a/lanelet2_projection/CMakeLists.txt
+++ b/lanelet2_projection/CMakeLists.txt
@@ -6,17 +6,11 @@ project(lanelet2_projection)
 ###################
 ## find packages ##
 ###################
+find_package(
+  catkin REQUIRED COMPONENTS
+  lanelet2_io
+)
 find_package(mrt_cmake_modules REQUIRED)
-include(UseMrtStdCompilerFlags)
-include(UseMrtAutoTarget)
-
-include(GatherDeps)
-# Remove libs which cannot be found automatically
-#list(REMOVE_ITEM DEPENDEND_PACKAGES <package name 1> <package name 2> ...)
-find_package(AutoDeps REQUIRED COMPONENTS ${DEPENDEND_PACKAGES})
-
-# Manually resolve removed dependend packages
-#find_package(...)
 
 # Mark files or folders for display in IDEs
 mrt_add_to_ide(README.md .gitlab-ci.yml)
@@ -30,10 +24,11 @@ mrt_python_module_setup()
 
 file(GLOB PROJECT_PYTHON_SOURCE_FILES_SRC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "python_api/*.cpp")
 if (PROJECT_PYTHON_SOURCE_FILES_SRC)
-    # Add a cpp-python api library. Make sure there are no name collisions with python modules in this project
-    mrt_add_python_api( ${PROJECT_NAME}
-        FILES ${PROJECT_PYTHON_SOURCE_FILES_SRC}
-        )
+  # Add a cpp-python api library. Make sure there are no name collisions with python modules in this project
+  mrt_add_python_api(
+    ${PROJECT_NAME}
+    FILES ${PROJECT_PYTHON_SOURCE_FILES_SRC}
+  )
 endif()
 
 ############################
@@ -44,7 +39,7 @@ file(GLOB PROJECT_SOURCE_FILES_INC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "src/*.h
 file(GLOB PROJECT_SOURCE_FILES_SRC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "src/*.cpp")
 
 if (PROJECT_SOURCE_FILES_SRC)
-    set(LIBRARY_NAME ${PROJECT_NAME})
+  set(LIBRARY_NAME ${PROJECT_NAME})
 endif()
 
 ###################################
@@ -57,30 +52,25 @@ endif()
 # CATKIN_DEPENDS: catkin_packages dependent projects also need
 # DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-    INCLUDE_DIRS include ${mrt_EXPORT_INCLUDE_DIRS}
-    LIBRARIES ${LIBRARY_NAME} ${mrt_EXPORT_LIBRARIES}
-    CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
-    )
+  INCLUDE_DIRS include
+  LIBRARIES ${LIBRARY_NAME}
+  CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
+)
 
 ###########
 ## Build ##
 ###########
 # Add include and library directories
 include_directories(
-    include/${PROJECT_NAME}
-    ${mrt_INCLUDE_DIRS}
-    ${catkin_INCLUDE_DIRS}
-    )
-
-link_directories(
-    ${mrt_LIBRARY_DIRS}
-    )
+  include/${PROJECT_NAME}
+  ${catkin_INCLUDE_DIRS}
+)
 
 # Declare a cpp library
 mrt_add_library(${PROJECT_NAME}
-    INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
-    SOURCES ${PROJECT_SOURCE_FILES_SRC}
-    )
+  INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
+  SOURCES ${PROJECT_SOURCE_FILES_SRC}
+)
 
 #############
 ## Install ##
@@ -93,6 +83,6 @@ mrt_install(PROGRAMS scripts FILES res data)
 #############
 # Add test targets for cpp and python tests
 if (CATKIN_ENABLE_TESTING)
-    mrt_add_tests(test)
-    mrt_add_nosetests(test)
+  mrt_add_tests(test)
+  mrt_add_nosetests(test)
 endif()

--- a/lanelet2_projection/package.xml
+++ b/lanelet2_projection/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>mrt_cmake_modules</build_depend>
   <test_depend>gtest</test_depend>
+  <depend>lanelet2_core</depend>
   <depend>lanelet2_io</depend>
   <depend>geographiclib</depend>
 

--- a/lanelet2_python/CMakeLists.txt
+++ b/lanelet2_python/CMakeLists.txt
@@ -73,6 +73,7 @@ include_directories(
 mrt_add_library(${PROJECT_NAME}
   INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
   SOURCES ${PROJECT_SOURCE_FILES_SRC}
+  LIBRARIES ${BoostPython_LIBRARIES}
 )
 
 #############

--- a/lanelet2_python/CMakeLists.txt
+++ b/lanelet2_python/CMakeLists.txt
@@ -6,17 +6,16 @@ project(lanelet2_python)
 ###################
 ## find packages ##
 ###################
+find_package(
+  catkin REQUIRED COMPONENTS
+  lanelet2_core
+  lanelet2_io
+  lanelet2_routing
+  lanelet2_traffic_rules
+  lanelet2_projection
+)
 find_package(mrt_cmake_modules REQUIRED)
-include(UseMrtStdCompilerFlags)
-include(UseMrtAutoTarget)
-
-include(GatherDeps)
-# Remove libs which cannot be found automatically
-#list(REMOVE_ITEM DEPENDEND_PACKAGES <package name 1> <package name 2> ...)
-find_package(AutoDeps REQUIRED COMPONENTS ${DEPENDEND_PACKAGES})
-
-# Manually resolve removed dependend packages
-#find_package(...)
+find_package(BoostPython REQUIRED)
 
 # Mark files or folders for display in IDEs
 mrt_add_to_ide(README.md .gitlab-ci.yml)
@@ -29,10 +28,11 @@ mrt_python_module_setup()
 
 file(GLOB PROJECT_PYTHON_SOURCE_FILES_SRC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "python_api/*.cpp")
 if (PROJECT_PYTHON_SOURCE_FILES_SRC)
-    # Add a cpp-python api library. Make sure there are no name collisions with python modules in this project
-    mrt_add_python_api( lanelet2
-        FILES ${PROJECT_PYTHON_SOURCE_FILES_SRC}
-        )
+  # Add a cpp-python api library. Make sure there are no name collisions with python modules in this project
+  mrt_add_python_api(
+    lanelet2
+    FILES ${PROJECT_PYTHON_SOURCE_FILES_SRC}
+  )
 endif()
 
 ############################
@@ -43,7 +43,7 @@ file(GLOB PROJECT_SOURCE_FILES_INC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "src/*.h
 file(GLOB PROJECT_SOURCE_FILES_SRC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "src/*.cpp")
 
 if (PROJECT_SOURCE_FILES_SRC)
-    set(LIBRARY_NAME ${PROJECT_NAME})
+  set(LIBRARY_NAME ${PROJECT_NAME})
 endif()
 
 ###################################
@@ -56,29 +56,24 @@ endif()
 # CATKIN_DEPENDS: catkin_packages dependent projects also need
 # DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-    INCLUDE_DIRS ${mrt_EXPORT_INCLUDE_DIRS}
-    LIBRARIES ${LIBRARY_NAME} ${mrt_EXPORT_LIBRARIES}
-    CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
-    )
+  LIBRARIES ${LIBRARY_NAME}
+  CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
+)
 
 ###########
 ## Build ##
 ###########
 # Add include and library directories
 include_directories(
-    ${mrt_INCLUDE_DIRS}
-    ${catkin_INCLUDE_DIRS}
-    )
-
-link_directories(
-    ${mrt_LIBRARY_DIRS}
-    )
+  ${BoostPython_INCLUDE_DIRS}
+  ${catkin_INCLUDE_DIRS}
+)
 
 # Declare a cpp library
 mrt_add_library(${PROJECT_NAME}
-    INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
-    SOURCES ${PROJECT_SOURCE_FILES_SRC}
-    )
+  INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
+  SOURCES ${PROJECT_SOURCE_FILES_SRC}
+)
 
 #############
 ## Install ##
@@ -91,6 +86,6 @@ mrt_install(PROGRAMS scripts FILES res data)
 #############
 # Add test targets for cpp and python tests
 if (CATKIN_ENABLE_TESTING)
-    mrt_add_tests(test)
-    mrt_add_nosetests(test)
+  mrt_add_tests(test)
+  mrt_add_nosetests(test)
 endif()

--- a/lanelet2_python/CMakeLists.txt
+++ b/lanelet2_python/CMakeLists.txt
@@ -3,6 +3,10 @@ set(MRT_PKG_VERSION 2.2)
 cmake_minimum_required(VERSION 2.8.12)
 project(lanelet2_python)
 
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
 ###################
 ## find packages ##
 ###################

--- a/lanelet2_routing/CMakeLists.txt
+++ b/lanelet2_routing/CMakeLists.txt
@@ -4,20 +4,17 @@ cmake_minimum_required(VERSION 2.8.12)
 project(lanelet2_routing)
 set(MRT_COTIRE_ENABLED 1)
 
+add_definitions(-std=c++14)
+
 ###################
 ## find packages ##
 ###################
+find_package(
+  catkin REQUIRED COMPONENTS
+  lanelet2_core
+  lanelet2_traffic_rules
+)
 find_package(mrt_cmake_modules REQUIRED)
-include(UseMrtStdCompilerFlags)
-include(UseMrtAutoTarget)
-
-include(GatherDeps)
-# Remove libs which cannot be found automatically
-#list(REMOVE_ITEM DEPENDEND_PACKAGES <package name 1> <package name 2> ...)
-find_package(AutoDeps REQUIRED COMPONENTS ${DEPENDEND_PACKAGES})
-
-# Manually resolve removed dependend packages
-#find_package(...)
 
 # Mark files or folders for display in IDEs
 mrt_add_to_ide(README.md .gitlab-ci.yml)
@@ -30,10 +27,11 @@ mrt_python_module_setup()
 
 file(GLOB PROJECT_PYTHON_SOURCE_FILES_SRC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "python_api/*.cpp")
 if (PROJECT_PYTHON_SOURCE_FILES_SRC)
-    # Add a cpp-python api library. Make sure there are no name collisions with python modules in this project
-    mrt_add_python_api( ${PROJECT_NAME}
-        FILES ${PROJECT_PYTHON_SOURCE_FILES_SRC}
-        )
+  # Add a cpp-python api library. Make sure there are no name collisions with python modules in this project
+  mrt_add_python_api(
+    ${PROJECT_NAME}
+    FILES ${PROJECT_PYTHON_SOURCE_FILES_SRC}
+  )
 endif()
 
 ############################
@@ -44,7 +42,7 @@ file(GLOB PROJECT_SOURCE_FILES_INC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "src/*.h
 file(GLOB PROJECT_SOURCE_FILES_SRC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "src/*.cpp")
 
 if (PROJECT_SOURCE_FILES_SRC)
-    set(LIBRARY_NAME ${PROJECT_NAME})
+  set(LIBRARY_NAME ${PROJECT_NAME})
 endif()
 
 ###################################
@@ -57,30 +55,25 @@ endif()
 # CATKIN_DEPENDS: catkin_packages dependent projects also need
 # DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-    INCLUDE_DIRS include ${mrt_EXPORT_INCLUDE_DIRS}
-    LIBRARIES ${LIBRARY_NAME} ${mrt_EXPORT_LIBRARIES}
-    CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
-    )
+  INCLUDE_DIRS include
+  LIBRARIES ${LIBRARY_NAME}
+  CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
+)
 
 ###########
 ## Build ##
 ###########
 # Add include and library directories
 include_directories(
-    include/${PROJECT_NAME}
-    ${mrt_INCLUDE_DIRS}
-    ${catkin_INCLUDE_DIRS}
-    )
-
-link_directories(
-    ${mrt_LIBRARY_DIRS}
-    )
+  include/${PROJECT_NAME}
+  ${catkin_INCLUDE_DIRS}
+)
 
 # Declare a cpp library
 mrt_add_library(${PROJECT_NAME}
-    INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
-    SOURCES ${PROJECT_SOURCE_FILES_SRC}
-    )
+  INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
+  SOURCES ${PROJECT_SOURCE_FILES_SRC}
+)
 
 #############
 ## Install ##
@@ -93,6 +86,6 @@ mrt_install(PROGRAMS scripts FILES res data)
 #############
 # Add test targets for cpp and python tests
 if (CATKIN_ENABLE_TESTING)
-    mrt_add_tests(test)
-    mrt_add_nosetests(test)
+  mrt_add_tests(test)
+  mrt_add_nosetests(test)
 endif()

--- a/lanelet2_routing/CMakeLists.txt
+++ b/lanelet2_routing/CMakeLists.txt
@@ -4,7 +4,9 @@ cmake_minimum_required(VERSION 2.8.12)
 project(lanelet2_routing)
 set(MRT_COTIRE_ENABLED 1)
 
-add_definitions(-std=c++14)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
 ###################
 ## find packages ##

--- a/lanelet2_traffic_rules/CMakeLists.txt
+++ b/lanelet2_traffic_rules/CMakeLists.txt
@@ -3,7 +3,9 @@ set(MRT_PKG_VERSION 2.2)
 cmake_minimum_required(VERSION 2.8.12)
 project(lanelet2_traffic_rules)
 
-add_definitions(-std=c++14)
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
 ###################
 ## find packages ##

--- a/lanelet2_traffic_rules/CMakeLists.txt
+++ b/lanelet2_traffic_rules/CMakeLists.txt
@@ -3,20 +3,16 @@ set(MRT_PKG_VERSION 2.2)
 cmake_minimum_required(VERSION 2.8.12)
 project(lanelet2_traffic_rules)
 
+add_definitions(-std=c++14)
+
 ###################
 ## find packages ##
 ###################
+find_package(
+  catkin REQUIRED COMPONENTS
+  lanelet2_core
+)
 find_package(mrt_cmake_modules REQUIRED)
-include(UseMrtStdCompilerFlags)
-include(UseMrtAutoTarget)
-
-include(GatherDeps)
-# Remove libs which cannot be found automatically
-#list(REMOVE_ITEM DEPENDEND_PACKAGES <package name 1> <package name 2> ...)
-find_package(AutoDeps REQUIRED COMPONENTS ${DEPENDEND_PACKAGES})
-
-# Manually resolve removed dependend packages
-#find_package(...)
 
 # Mark files or folders for display in IDEs
 mrt_add_to_ide(README.md .gitlab-ci.yml)
@@ -29,10 +25,11 @@ mrt_python_module_setup()
 
 file(GLOB PROJECT_PYTHON_SOURCE_FILES_SRC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "python_api/*.cpp")
 if (PROJECT_PYTHON_SOURCE_FILES_SRC)
-    # Add a cpp-python api library. Make sure there are no name collisions with python modules in this project
-    mrt_add_python_api( ${PROJECT_NAME}
-        FILES ${PROJECT_PYTHON_SOURCE_FILES_SRC}
-        )
+  # Add a cpp-python api library. Make sure there are no name collisions with python modules in this project
+  mrt_add_python_api(
+    ${PROJECT_NAME}
+    FILES ${PROJECT_PYTHON_SOURCE_FILES_SRC}
+  )
 endif()
 
 ############################
@@ -43,7 +40,7 @@ file(GLOB PROJECT_SOURCE_FILES_INC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "src/*.h
 file(GLOB PROJECT_SOURCE_FILES_SRC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "src/*.cpp")
 
 if (PROJECT_SOURCE_FILES_SRC)
-    set(LIBRARY_NAME ${PROJECT_NAME})
+  set(LIBRARY_NAME ${PROJECT_NAME})
 endif()
 
 ###################################
@@ -56,30 +53,25 @@ endif()
 # CATKIN_DEPENDS: catkin_packages dependent projects also need
 # DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-    INCLUDE_DIRS include ${mrt_EXPORT_INCLUDE_DIRS}
-    LIBRARIES ${LIBRARY_NAME} ${mrt_EXPORT_LIBRARIES}
-    CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
-    )
+  INCLUDE_DIRS include
+  LIBRARIES ${LIBRARY_NAME}
+  CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
+)
 
 ###########
 ## Build ##
 ###########
 # Add include and library directories
 include_directories(
-    include/${PROJECT_NAME}
-    ${mrt_INCLUDE_DIRS}
-    ${catkin_INCLUDE_DIRS}
-    )
-
-link_directories(
-    ${mrt_LIBRARY_DIRS}
-    )
+  include/${PROJECT_NAME}
+  ${catkin_INCLUDE_DIRS}
+)
 
 # Declare a cpp library
 mrt_add_library(${PROJECT_NAME}
-    INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
-    SOURCES ${PROJECT_SOURCE_FILES_SRC}
-    )
+  INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
+  SOURCES ${PROJECT_SOURCE_FILES_SRC}
+)
 
 #############
 ## Install ##
@@ -92,6 +84,6 @@ mrt_install(PROGRAMS scripts FILES res data)
 #############
 # Add test targets for cpp and python tests
 if (CATKIN_ENABLE_TESTING)
-    mrt_add_tests(test)
-    mrt_add_nosetests(test)
+  mrt_add_tests(test)
+  mrt_add_nosetests(test)
 endif()

--- a/lanelet2_validation/CMakeLists.txt
+++ b/lanelet2_validation/CMakeLists.txt
@@ -3,6 +3,11 @@ set(MRT_PKG_VERSION 2.2.1)
 cmake_minimum_required(VERSION 2.8.12)
 project(lanelet2_validation)
 
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+
 ###################
 ## find packages ##
 ###################

--- a/lanelet2_validation/CMakeLists.txt
+++ b/lanelet2_validation/CMakeLists.txt
@@ -6,17 +6,15 @@ project(lanelet2_validation)
 ###################
 ## find packages ##
 ###################
+find_package(
+  catkin REQUIRED COMPONENTS
+  lanelet2_core
+  lanelet2_routing
+  lanelet2_io
+  lanelet2_projection
+  lanelet2_traffic_rules
+)
 find_package(mrt_cmake_modules REQUIRED)
-include(UseMrtStdCompilerFlags)
-include(UseMrtAutoTarget)
-
-include(GatherDeps)
-# Remove libs which cannot be found automatically
-#list(REMOVE_ITEM DEPENDEND_PACKAGES <package name 1> <package name 2> ...)
-find_package(AutoDeps REQUIRED COMPONENTS ${DEPENDEND_PACKAGES})
-
-# Manually resolve removed dependend packages
-#find_package(...)
 
 # Mark files or folders for display in IDEs
 mrt_add_to_ide(README.md .gitlab-ci.yml)
@@ -30,10 +28,11 @@ mrt_python_module_setup()
 
 file(GLOB PROJECT_PYTHON_SOURCE_FILES_SRC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "python_api/*.cpp")
 if (PROJECT_PYTHON_SOURCE_FILES_SRC)
-    # Add a cpp-python api library. Make sure there are no name collisions with python modules in this project
-    mrt_add_python_api( ${PROJECT_NAME}
-        FILES ${PROJECT_PYTHON_SOURCE_FILES_SRC}
-        )
+  # Add a cpp-python api library. Make sure there are no name collisions with python modules in this project
+  mrt_add_python_api(
+    ${PROJECT_NAME}
+    FILES ${PROJECT_PYTHON_SOURCE_FILES_SRC}
+  )
 endif()
 
 ############################
@@ -44,7 +43,7 @@ file(GLOB_RECURSE PROJECT_SOURCE_FILES_INC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" 
 file(GLOB_RECURSE PROJECT_SOURCE_FILES_SRC RELATIVE "${CMAKE_CURRENT_LIST_DIR}" "src/*.cpp")
 
 if (PROJECT_SOURCE_FILES_SRC)
-    set(LIBRARY_NAME ${PROJECT_NAME})
+  set(LIBRARY_NAME ${PROJECT_NAME})
 endif()
 
 ###################################
@@ -57,41 +56,37 @@ endif()
 # CATKIN_DEPENDS: catkin_packages dependent projects also need
 # DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-    INCLUDE_DIRS include ${mrt_EXPORT_INCLUDE_DIRS}
-    LIBRARIES ${LIBRARY_NAME} ${mrt_EXPORT_LIBRARIES}
-    CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
-    )
+  INCLUDE_DIRS include
+  LIBRARIES ${LIBRARY_NAME}
+  CATKIN_DEPENDS ${catkin_EXPORT_DEPENDS}
+)
 
 ###########
 ## Build ##
 ###########
 # Add include and library directories
 include_directories(
-    include/${PROJECT_NAME}
-    ${mrt_INCLUDE_DIRS}
-    ${catkin_INCLUDE_DIRS}
-    )
-
-link_directories(
-    ${mrt_LIBRARY_DIRS}
-    )
+  include/${PROJECT_NAME}
+  ${catkin_INCLUDE_DIRS}
+)
 
 # Declare a cpp library
-mrt_add_library(${PROJECT_NAME}
-    INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
-    SOURCES ${PROJECT_SOURCE_FILES_SRC}
-    )
+mrt_add_library(
+  ${PROJECT_NAME}
+  INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC} 
+  SOURCES ${PROJECT_SOURCE_FILES_SRC}
+)
 
 # Add executables in "tools"
 glob_folders(TOOL_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/tools")
 if (TOOL_DIRECTORIES)
-    # Found subfolders, add executable for each subfolder
-    foreach(TOOL_DIR ${TOOL_DIRECTORIES})
-        mrt_add_executable(${TOOL_DIR} FOLDER "tools/${TOOL_DIR}")
-    endforeach()
+  # Found subfolders, add executable for each subfolder
+  foreach(TOOL_DIR ${TOOL_DIRECTORIES})
+    mrt_add_executable(${TOOL_DIR} FOLDER "tools/${TOOL_DIR}")
+  endforeach()
 else()
-    # No subfolder found, add executable and python modules for tools folder
-    mrt_add_executable(${PROJECT_NAME} FOLDER "tools")
+  # No subfolder found, add executable and python modules for tools folder
+  mrt_add_executable(${PROJECT_NAME} FOLDER "tools")
 endif()
 
 
@@ -106,6 +101,6 @@ mrt_install(PROGRAMS scripts FILES res data)
 #############
 # Add test targets for cpp and python tests
 if (CATKIN_ENABLE_TESTING)
-    mrt_add_tests(test)
-    mrt_add_nosetests(test)
+  mrt_add_tests(test)
+  mrt_add_nosetests(test)
 endif()


### PR DESCRIPTION
Lanelet2 is required by the Autoware.ai project (https://gitlab.com/autowarefoundation/autoware.ai). Autoware is built on several platforms (arm64, aarch64, armel, armhf, etc.) and needs to be able to be cross-compiled for these platforms. Unfortunately, the `mrt_cmake_modules` package is very Intel-specific and does not work well with a non-x86 sysroot in Linux environments. The easiest way to alleviate this is to remove the most troublesome part of `mrt_cmake_modules` - the auto-dependency generation - from Lanelet2. I have tested the changes below on ROS Kinetic and ROS Melodic on amd64 and aarch64 architectures.