### PR TITLE
Add missing const in Area.h regulatoryElementsAs method

### DIFF
--- a/lanelet2_core/include/lanelet2_core/primitives/Area.h
+++ b/lanelet2_core/include/lanelet2_core/primitives/Area.h
@@ -72,7 +72,7 @@ class AreaData : public PrimitiveData {
   RegulatoryElementPtrs& regulatoryElements() { return regulatoryElements_; }
 
   template <typename RegElemT>
-  std::vector<std::shared_ptr<RegElemT>> regulatoryElementsAs() const {
+  std::vector<std::shared_ptr<const RegElemT>> regulatoryElementsAs() const {
     return utils::transformSharedPtr<const RegElemT>(regulatoryElements_);
   }
   template <typename RegElemT>

--- a/lanelet2_core/include/lanelet2_core/primitives/LaneletOrArea.h
+++ b/lanelet2_core/include/lanelet2_core/primitives/LaneletOrArea.h
@@ -62,7 +62,7 @@ class ConstLaneletOrArea {
 
   template <typename T>
   std::vector<std::shared_ptr<const T>> regulatoryElementsAs() const {
-    return applyVisitor([](auto& elem) { return elem.template regulatoryElementAs<T>(); });
+    return applyVisitor([](auto& elem) { return elem.template regulatoryElementsAs<T>(); });
   }
 
   //! return the managed lanelet


### PR DESCRIPTION
The primitives/Area.h file had a regulatoryElementsAs overload that appeared to be missing a const return value. 
```
  template <typename RegElemT>
  std::vector<std::shared_ptr<RegElemT>> regulatoryElementsAs() const { // Return does not match 
    return utils::transformSharedPtr<const RegElemT>(regulatoryElements_); // Return does not match
  }
  template <typename RegElemT>
  std::vector<std::shared_ptr<RegElemT>> regulatoryElementsAs() {
    return utils::transformSharedPtr<RegElemT>(regulatoryElements_);
  }
```
This PR adds the missing const value such that the Area.h regulatoryElementsAs methods match the Lanelet methods. 

In addition this PR fixes a typo in LaneletOrArea.h which was calling regulatoryElementAs instead of regulatoryElementsAs (Elements needed an ending "s")
```
 template <typename T>
  std::vector<std::shared_ptr<const T>> regulatoryElementsAs() const {
    return applyVisitor([](auto& elem) { return elem.template regulatoryElementAs<T>(); });
  }
```
The unit tests still pass. 