### PR TITLE
Add proj local frame projector

### DIFF
--- a/lanelet2_projection/include/lanelet2_projection/LocalFrameProjector.h
+++ b/lanelet2_projection/include/lanelet2_projection/LocalFrameProjector.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2015-2019 Autoware Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors: Shuwei Qiang
+ */
+
+/*
+ * Modifications:
+ *  - Added class comments and tweaked some function comments
+ *    - 1/16/2020
+ *    - Michael McConnell
+ */
+
+#ifndef LANELET2_EXTENSION_PROJECTION_LOCAL_FRAME_PROJECTOR_H
+#define LANELET2_EXTENSION_PROJECTION_LOCAL_FRAME_PROJECTOR_H
+
+#include <proj.h>
+#include <lanelet2_io/Projection.h>
+
+#include <string>
+
+namespace lanelet
+{
+namespace projection
+{
+
+  /**
+   * LocalFrameProjector uses the Proj library to project maps based on provided proj strings
+   * See https://proj.org/ for details on Proj library api and string definitions
+   * 
+   * Example Usage
+   * 
+   * LocalFrameProjector proj = LocalFrameProjector('EPSG:4326', '+proj=tmerc +lat_0=38.85197911150576 +lon_0=-77.24835128349988 +k=1 +x_0=0 +y_0=0 +units=m +vunits=m');
+   * 
+   * The above projection can now be used for converting points from a lat/lon reference in EPSG:4326 (WGS84) to a more local transverse mercator x,y frame.
+   * 
+   */
+class LocalFrameProjector : public Projector
+{
+
+public:
+
+  explicit LocalFrameProjector(const char* base_frame, const char* target_frame, Origin origin = Origin({ 0.0, 0.0 }));
+
+  /**
+   * [LocalFrameProjector::forward projects gps lat/lon to local map frame]
+   * @param  gps [point with latitude longitude information]
+   * @return     [projected point in local map coordinate]
+   */
+  BasicPoint3d forward(const GPSPoint& p) const override;
+
+  /**
+   * [LocalFrameProjector::reverse projects point within local map frame into gps lat/lon]
+   * @param  local_point [3d point in local map frame]
+   * @return             [projected point]
+   */
+  GPSPoint reverse(const BasicPoint3d& p) const override;
+
+private:
+  
+  PJ *P;
+};
+
+}  // namespace projection
+}  // namespace lanelet
+
+#endif  // LANELET2_EXTENSION_PROJECTION_LOCAL_FRAME_PROJECTOR_H

--- a/lanelet2_projection/src/LocalFrameProjector.cpp
+++ b/lanelet2_projection/src/LocalFrameProjector.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015-2019 Autoware Foundation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Authors: Shuwei Qiang
+ */
+
+#include <lanelet2_extension/projection/LocalFrameProjector.h>
+#include <iostream>
+
+namespace lanelet
+{
+namespace projection
+{
+
+LocalFrameProjector::LocalFrameProjector(const char* base_frame, const char* target_frame, Origin origin) : Projector(origin)
+{
+  P = proj_create_crs_to_crs(PJ_DEFAULT_CTX, base_frame, target_frame, NULL);
+}
+
+BasicPoint3d LocalFrameProjector::forward(const GPSPoint& p) const
+{
+  PJ_COORD c{{p.lat, p.lon, p.ele, 0}};
+  PJ_COORD c_out = proj_trans(P, PJ_FWD, c);
+  return BasicPoint3d{c_out.xy.x, c_out.xy.y, 0};
+}
+
+GPSPoint LocalFrameProjector::reverse(const BasicPoint3d& p) const
+{
+  PJ_COORD c{{p[0], p[1], p[2], 0}};
+  PJ_COORD c_out = proj_trans(P, PJ_INV, c);
+  return GPSPoint{c_out.lp.lam, c_out.lp.phi};
+}
+
+}  // namespace projection
+}  // namespace lanelet
+


### PR DESCRIPTION
This PR adds a projector that uses the common [Proj Library](https://proj.org/) to allow projections between arbitrary geodesic and Cartesian reference frames. The projector takes in a base frame and target frame specified as proj library strings and generates the necessary projection between the two. 

This PR is based off source code originally developed as part of the [CARMA Platform](https://github.com/usdot-fhwa-stol/CARMAPlatform) and requested as a PR to this repo by the [Autoware Foundation](https://gitlab.com/autowarefoundation) 

Original Source Code: https://github.com/usdot-fhwa-stol/autoware.ai/blob/carma-develop/common/lanelet2_extension/include/lanelet2_extension/projection/local_frame_projector.h

NOTE: Not yet ready to merge. 
There is still some work required to make this code functional as this creates a dependency on the Proj library and will require updates to the CMakeList.txt file. 
How would the Lanelet2 maintainers prefer such dependencies be managed? 

