### PR TITLE
Add pragma once to traffic_rules/Exceptions.h

### DIFF
--- a/lanelet2_traffic_rules/include/lanelet2_traffic_rules/Exceptions.h
+++ b/lanelet2_traffic_rules/include/lanelet2_traffic_rules/Exceptions.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <lanelet2_core/Exceptions.h>
 
 namespace lanelet {


### PR DESCRIPTION
The Exceptions.h file in lanelet2_traffic_rules was missing its include guard which could result in an error such as
```
error: redefinition of ‘class lanelet::InterpretationError’
```
This PR adds the pragma once include guard to prevent that