### PR TITLE
Fix of an errors in the work python_api

### DIFF
--- a/lanelet2_python/python_api/core.cpp
+++ b/lanelet2_python/python_api/core.cpp
@@ -459,6 +459,7 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
   VectorToListConverter<LineStringsOrPolygons3d>();
   VectorToListConverter<ConstLineStringsOrPolygons3d>();
   VectorToListConverter<ConstLaneletOrAreas>();
+  VectorToListConverter<Areas>();
   VectorToListConverter<std::vector<TrafficLight::Ptr>>();
   VectorToListConverter<std::vector<TrafficSign::Ptr>>();
   VectorToListConverter<std::vector<SpeedLimit::Ptr>>();

--- a/lanelet2_python/python_api/routing.cpp
+++ b/lanelet2_python/python_api/routing.cpp
@@ -137,7 +137,7 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
            "Initialization from a submap")
       .def("getRoute", getRouteWrapper, "driving route from 'start' to 'end' lanelet",
            (arg("from"), arg("to"), arg("routingCostId") = 0, arg("withLaneChanges") = true))
-      .def("getRouteVia", getRouteWrapper, "driving route from 'start' to 'end' lanelet using the 'via' lanelets",
+      .def("getRouteVia", getRouteViaWrapper, "driving route from 'start' to 'end' lanelet using the 'via' lanelets",
            (arg("from"), arg("via"), arg("to"), arg("routingCostId") = 0, arg("withLaneChanges") = true))
       .def("shortestPath", &RoutingGraph::shortestPath, "shortest path between 'start' and 'end'",
            (arg("from"), arg("to"), arg("routingCostId") = 0))


### PR DESCRIPTION
### Fix bugs:
An error occurs when using the `findUsages` are `areaLayer` function:

Example of use:
```
for lineString in tqdm (graph.lineStringLayer):
    print (graph.areaLayer.findUsages (lineString))
```

Error that occurs:

> TypeError: No to_python (by-value) converter found for C++ type: std::vector<lanelet::Area, std::allocator<lanelet::Area> >

When calling a function `getRouteVia(...)`, the function was called `getRoute(...)`. Invalid function signature.

Example of use:
```
start = map.laneletLayer[13075]
middle = map.laneletLayer[4304]
finish = map.laneletLayer[4309]
route = graph.getRouteVia(start, [middle], finish)
```

Error that occurs:
> Boost.Python.ArgumentError: Python argument types in
>     RoutingGraph.getRouteVia(RoutingGraph, Lanelet, list, Lanelet)
> did not match C++ signature:
>     getRouteVia(lanelet::routing::RoutingGraph from, lanelet::ConstLanelet via, lanelet::ConstLanelet to, unsigned short routingCostId=0, bool withLaneChanges=True)

### Bug Fix Implementation:
findUsages(...)
added `VectorToListConverter<Areas>()` to `lanelet2_python/python_api/core.cpp`

getRouteVia(...)
`.def("getRoute", getRouteWrapper, ...)` change to `.def("getRouteVia", getRouteViaWrapper, ...)`
