### PR TITLE
use libboost-python-dev to depend on the version providing the headers

### DIFF
--- a/lanelet2_python/package.xml
+++ b/lanelet2_python/package.xml
@@ -17,7 +17,7 @@
   <depend>lanelet2_routing</depend>
   <depend>lanelet2_traffic_rules</depend>
   <depend>lanelet2_projection</depend>
-  <depend>libboost-python</depend>
+  <depend>libboost-python-dev</depend>
   <export>
   </export>
 </package>


### PR DESCRIPTION
Change related to and depending on https://github.com/ros/rosdistro/pull/23844

@JWhitleyWork FYI