### PR TITLE
Updating package.xml files to format 3.

### DIFF
--- a/lanelet2/package.xml
+++ b/lanelet2/package.xml
@@ -1,4 +1,6 @@
-<package format="2">
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>lanelet2</name>
   <version>1.0.1</version>
   <description>Meta-package for lanelet2</description>

--- a/lanelet2_core/package.xml
+++ b/lanelet2_core/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>lanelet2_core</name>
   <version>1.0.1</version>
   <description>Lanelet2 core module</description>

--- a/lanelet2_examples/package.xml
+++ b/lanelet2_examples/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>lanelet2_examples</name>
   <version>1.0.1</version>
   <description>Examples for working with Lanelet2</description>

--- a/lanelet2_io/package.xml
+++ b/lanelet2_io/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>lanelet2_io</name>
   <version>1.0.1</version>
   <description>Parser/Writer module for lanelet2</description>

--- a/lanelet2_maps/package.xml
+++ b/lanelet2_maps/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>lanelet2_maps</name>
   <version>1.0.1</version>
   <description>Example maps in the lanelet2-format</description>

--- a/lanelet2_projection/package.xml
+++ b/lanelet2_projection/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>lanelet2_projection</name>
   <version>1.0.1</version>
   <description>Lanelet2 projection library for lat/lon to local x/y conversion</description>
@@ -15,7 +16,6 @@
   <test_depend>gtest</test_depend>
   <depend>lanelet2_io</depend>
   <depend>geographiclib</depend>
-
 
   <export>
     <rosdoc config="../rosdoc.yaml" />

--- a/lanelet2_python/package.xml
+++ b/lanelet2_python/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>lanelet2_python</name>
   <version>1.0.1</version>
   <description>Python bindings for lanelet2</description>

--- a/lanelet2_routing/package.xml
+++ b/lanelet2_routing/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>lanelet2_routing</name>
   <version>1.0.1</version>
   <description>Routing module for lanelet2</description>

--- a/lanelet2_traffic_rules/package.xml
+++ b/lanelet2_traffic_rules/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>lanelet2_traffic_rules</name>
   <version>1.0.1</version>
   <description>Package for interpreting traffic rules in a lanelet map</description>

--- a/lanelet2_validation/package.xml
+++ b/lanelet2_validation/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>lanelet2_validation</name>
   <version>1.0.1</version>
   <description>Package for sanitizing lanelet maps</description>


### PR DESCRIPTION
As a precursor to #112, the `package.xml` files must be updated to use format 3 to support the `condition` attribute. This should not negatively impact builds in ROS 1.