### PR TITLE
Removing extra semicolons causing warnings with wpedantic.

### DIFF
--- a/lanelet2_core/include/lanelet2_core/geometry/BoundingBox.h
+++ b/lanelet2_core/include/lanelet2_core/geometry/BoundingBox.h
@@ -4,8 +4,8 @@
 #include "lanelet2_core/primitives/BoundingBox.h"
 
 // registrations for use with boost::geometry
-BOOST_GEOMETRY_REGISTER_BOX(lanelet::BoundingBox2d, lanelet::BasicPoint2d, min(), max());
-BOOST_GEOMETRY_REGISTER_BOX(lanelet::BoundingBox3d, lanelet::BasicPoint3d, min(), max());
+BOOST_GEOMETRY_REGISTER_BOX(lanelet::BoundingBox2d, lanelet::BasicPoint2d, min(), max())
+BOOST_GEOMETRY_REGISTER_BOX(lanelet::BoundingBox3d, lanelet::BasicPoint3d, min(), max())
 
 namespace lanelet {
 namespace geometry {

--- a/lanelet2_core/include/lanelet2_core/geometry/LineString.h
+++ b/lanelet2_core/include/lanelet2_core/geometry/LineString.h
@@ -26,7 +26,7 @@ BOOST_GEOMETRY_REGISTER_LINESTRING(lanelet::CompoundLineString2d)
 BOOST_GEOMETRY_REGISTER_LINESTRING(lanelet::CompoundLineString3d)
 BOOST_GEOMETRY_REGISTER_LINESTRING(lanelet::CompoundHybridLineString2d)
 BOOST_GEOMETRY_REGISTER_LINESTRING(lanelet::CompoundHybridLineString3d)
-BOOST_GEOMETRY_REGISTER_SEGMENT_TEMPLATIZED(lanelet::Segment, first, second);
+BOOST_GEOMETRY_REGISTER_SEGMENT_TEMPLATIZED(lanelet::Segment, first, second)
 
 namespace lanelet {
 namespace geometry {

--- a/lanelet2_core/src/LineStringGeometry.cpp
+++ b/lanelet2_core/src/LineStringGeometry.cpp
@@ -169,7 +169,7 @@ std::pair<BasicPoint3d, BasicPoint3d> projectedPoint3d(const ConstHybridLineStri
 
 std::pair<BasicPoint3d, BasicPoint3d> projectedPoint3d(const BasicLineString3d& l1, const ConstHybridLineString3d& l2) {
   return projectedPoint3dImpl(l1, l2);
-};
+}
 
 std::pair<BasicPoint3d, BasicPoint3d> projectedPoint3d(const BasicLineString3d& l1, const BasicLineString3d& l2) {
   return projectedPoint3dImpl(l1, l2);

--- a/lanelet2_io/include/lanelet2_io/io_handlers/Serialize.h
+++ b/lanelet2_io/include/lanelet2_io/io_handlers/Serialize.h
@@ -484,18 +484,18 @@ void load(Archive& ar, lanelet::LaneletMap& m, unsigned int /*version*/) {
 }  // namespace serialization
 }  // namespace boost
 
-BOOST_SERIALIZATION_SPLIT_FREE(lanelet::AttributeMap);
-BOOST_SERIALIZATION_SPLIT_FREE(lanelet::Attribute);
-BOOST_SERIALIZATION_SPLIT_FREE(lanelet::WeakArea);
-BOOST_SERIALIZATION_SPLIT_FREE(lanelet::Area);
-BOOST_SERIALIZATION_SPLIT_FREE(lanelet::WeakLanelet);
-BOOST_SERIALIZATION_SPLIT_FREE(lanelet::Lanelet);
-BOOST_SERIALIZATION_SPLIT_FREE(lanelet::Point3d);
-BOOST_SERIALIZATION_SPLIT_FREE(lanelet::ConstPoint3d);  // NOLINT
-BOOST_SERIALIZATION_SPLIT_FREE(lanelet::LineString3d);
-BOOST_SERIALIZATION_SPLIT_FREE(lanelet::ConstLineString3d);  // NOLINT
-BOOST_SERIALIZATION_SPLIT_FREE(lanelet::Polygon3d);
-BOOST_SERIALIZATION_SPLIT_FREE(lanelet::RuleParameterMap);
-BOOST_SERIALIZATION_SPLIT_FREE(lanelet::RegulatoryElementPtr);
-BOOST_SERIALIZATION_SPLIT_FREE(lanelet::RegulatoryElementConstPtr);
-BOOST_SERIALIZATION_SPLIT_FREE(lanelet::LaneletMap);
+BOOST_SERIALIZATION_SPLIT_FREE(lanelet::AttributeMap)
+BOOST_SERIALIZATION_SPLIT_FREE(lanelet::Attribute)
+BOOST_SERIALIZATION_SPLIT_FREE(lanelet::WeakArea)
+BOOST_SERIALIZATION_SPLIT_FREE(lanelet::Area)
+BOOST_SERIALIZATION_SPLIT_FREE(lanelet::WeakLanelet)
+BOOST_SERIALIZATION_SPLIT_FREE(lanelet::Lanelet)
+BOOST_SERIALIZATION_SPLIT_FREE(lanelet::Point3d)
+BOOST_SERIALIZATION_SPLIT_FREE(lanelet::ConstPoint3d)  // NOLINT
+BOOST_SERIALIZATION_SPLIT_FREE(lanelet::LineString3d)
+BOOST_SERIALIZATION_SPLIT_FREE(lanelet::ConstLineString3d)  // NOLINT
+BOOST_SERIALIZATION_SPLIT_FREE(lanelet::Polygon3d)
+BOOST_SERIALIZATION_SPLIT_FREE(lanelet::RuleParameterMap)
+BOOST_SERIALIZATION_SPLIT_FREE(lanelet::RegulatoryElementPtr)
+BOOST_SERIALIZATION_SPLIT_FREE(lanelet::RegulatoryElementConstPtr)
+BOOST_SERIALIZATION_SPLIT_FREE(lanelet::LaneletMap)

--- a/lanelet2_python/python_api/geometry.cpp
+++ b/lanelet2_python/python_api/geometry.cpp
@@ -9,9 +9,9 @@
 #include <boost/python.hpp>
 #include "lanelet2_python/internal/converter.h"
 
-BOOST_GEOMETRY_REGISTER_MULTI_LINESTRING(lanelet::LineStrings2d);
-BOOST_GEOMETRY_REGISTER_MULTI_LINESTRING(lanelet::ConstLineStrings2d);
-BOOST_GEOMETRY_REGISTER_MULTI_LINESTRING(lanelet::ConstHybridLineStrings2d);
+BOOST_GEOMETRY_REGISTER_MULTI_LINESTRING(lanelet::LineStrings2d)
+BOOST_GEOMETRY_REGISTER_MULTI_LINESTRING(lanelet::ConstLineStrings2d)
+BOOST_GEOMETRY_REGISTER_MULTI_LINESTRING(lanelet::ConstHybridLineStrings2d)
 
 using namespace boost::python;
 using namespace lanelet;

--- a/lanelet2_routing/include/lanelet2_routing/Route.h
+++ b/lanelet2_routing/include/lanelet2_routing/Route.h
@@ -201,5 +201,5 @@ class Route {
   LaneletPath shortestPath_;                     ///< The underlying shortest path used to create the route
   LaneletSubmapConstPtr laneletSubmap_;          ///< LaneletSubmap with all lanelets that are part of the route
 };
-};  // namespace routing
-};  // namespace lanelet
+}  // namespace routing
+}  // namespace lanelet

--- a/lanelet2_traffic_rules/test/lanelet2_traffic_rules.cpp
+++ b/lanelet2_traffic_rules/test/lanelet2_traffic_rules.cpp
@@ -22,7 +22,7 @@ lanelet::RegulatoryElementPtr getSpeedLimit(const std::string& type, const lanel
 lanelet::traffic_rules::TrafficRulesPtr germanVehicleRules() {
   using namespace lanelet;
   return traffic_rules::TrafficRulesFactory::create(Locations::Germany, Participants::Vehicle, {});
-};
+}
 
 lanelet::traffic_rules::TrafficRulesPtr germanBikeRules() {
   using namespace lanelet;


### PR DESCRIPTION
When the flag `-Wpedantic` is enabled, warnings are generated about unnecessary semicolons. This removes those semicolons.