### PR TITLE
Expose readwrite struct members to python

### DIFF
--- a/lanelet2_python/python_api/core.cpp
+++ b/lanelet2_python/python_api/core.cpp
@@ -589,9 +589,9 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
                              return std::make_shared<GPSPoint>(GPSPoint({lat, lon, alt}));
                            },
                            default_call_policies(), (arg("lat") = 0., arg("lon") = 0., arg("alt") = 0)))
-      .add_property("lat", &GPSPoint::lat)
-      .add_property("lon", &GPSPoint::lon)
-      .add_property("alt", &GPSPoint::ele);
+      .def_readwrite("lat", &GPSPoint::lat)
+      .def_readwrite("lon", &GPSPoint::lon)
+      .def_readwrite("alt", &GPSPoint::ele);
 
   class_<ConstLineString2d>("ConstLineString2d", "Immutable 2d lineString primitive",
                             init<ConstLineString3d>("ConstLineString2d(ConstLineString3d)"))
@@ -746,12 +746,12 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
       .def("__getitem__", wrappers::getItem<LaneletSequence>, return_internal_reference<>());
 
   class_<ConstLaneletWithStopLine>("ConstLaneletWithStopLine", "A lanelet with a stopline", no_init)
-      .add_property("lanelet", &ConstLaneletWithStopLine::lanelet)
-      .add_property("stopLine", &ConstLaneletWithStopLine::stopLine);
+      .def_readwrite("lanelet", &ConstLaneletWithStopLine::lanelet)
+      .def_readwrite("stopLine", &ConstLaneletWithStopLine::stopLine);
 
   class_<LaneletWithStopLine>("LaneletWithStopLine", "A lanelet with a stopline", no_init)
-      .add_property("lanelet", &LaneletWithStopLine::lanelet)
-      .add_property("stopLine", &LaneletWithStopLine::stopLine);
+      .def_readwrite("lanelet", &LaneletWithStopLine::lanelet)
+      .def_readwrite("stopLine", &LaneletWithStopLine::stopLine);
 
   class_<ConstArea>("ConstArea", "Represents an area, potentially with holes, in the map",
                     boost::python::init<Id, LineStrings3d, InnerBounds, AttributeMap>(
@@ -849,8 +849,8 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
       .def("__init__", make_constructor(+[](LineStringsOrPolygons3d ls, std::string type) {
              return std::make_shared<TrafficSignsWithType>(TrafficSignsWithType{std::move(ls), std::move(type)});
            }))
-      .add_property("trafficSigns", &TrafficSignsWithType::trafficSigns)
-      .add_property("type", &TrafficSignsWithType::type);
+      .def_readwrite("trafficSigns", &TrafficSignsWithType::trafficSigns)
+      .def_readwrite("type", &TrafficSignsWithType::type);
 
   class_<TrafficSign, boost::noncopyable, std::shared_ptr<TrafficSign>, bases<RegulatoryElement>>(
       "TrafficSign", "A traffic sign regulatory element", no_init)

--- a/lanelet2_python/python_api/core.cpp
+++ b/lanelet2_python/python_api/core.cpp
@@ -746,12 +746,12 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
       .def("__getitem__", wrappers::getItem<LaneletSequence>, return_internal_reference<>());
 
   class_<ConstLaneletWithStopLine>("ConstLaneletWithStopLine", "A lanelet with a stopline", no_init)
-      .def_readwrite("lanelet", &ConstLaneletWithStopLine::lanelet)
-      .def_readwrite("stopLine", &ConstLaneletWithStopLine::stopLine);
+      .add_property("lanelet", &ConstLaneletWithStopLine::lanelet)
+      .add_property("stopLine", &ConstLaneletWithStopLine::stopLine);
 
   class_<LaneletWithStopLine>("LaneletWithStopLine", "A lanelet with a stopline", no_init)
-      .def_readwrite("lanelet", &LaneletWithStopLine::lanelet)
-      .def_readwrite("stopLine", &LaneletWithStopLine::stopLine);
+      .add_property("lanelet", &LaneletWithStopLine::lanelet)
+      .add_property("stopLine", &LaneletWithStopLine::stopLine);
 
   class_<ConstArea>("ConstArea", "Represents an area, potentially with holes, in the map",
                     boost::python::init<Id, LineStrings3d, InnerBounds, AttributeMap>(

--- a/lanelet2_python/python_api/geometry.cpp
+++ b/lanelet2_python/python_api/geometry.cpp
@@ -260,8 +260,8 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
   def("area", boost::geometry::area<ConstHybridPolygon2d>);
 
   class_<ArcCoordinates>("ArcCoordinates", "Coordinates along an arc", init<>())
-      .add_property("length", &ArcCoordinates::length, "lenght along arc")
-      .add_property("distance", &ArcCoordinates::distance, "signed distance to arc (left is positive");
+      .def_readwrite("length", &ArcCoordinates::length, "length along arc")
+      .def_readwrite("distance", &ArcCoordinates::distance, "signed distance to arc (left is positive");
 
   def("toArcCoordinates", lg::toArcCoordinates<ConstLineString2d>,
       "Project a point into arc coordinates of the linestring");

--- a/lanelet2_python/python_api/io.cpp
+++ b/lanelet2_python/python_api/io.cpp
@@ -42,7 +42,7 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
                              return std::make_shared<Origin>(GPSPoint{lat, lon, alt});
                            },
                            default_call_policies(), (arg("lat") = 0., arg("lon") = 0., arg("lon") = 0)))
-      .add_property("position", &Origin::position);
+      .def_readwrite("position", &Origin::position);
 
   def("load", loadProjectorWrapper, (arg("filename"), arg("projector") = DefaultProjector()));
   def("load", loadWrapper, (arg("filename"), arg("origin")));

--- a/lanelet2_python/python_api/routing.cpp
+++ b/lanelet2_python/python_api/routing.cpp
@@ -102,25 +102,25 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
 
   class_<LaneletVisitInformation>("LaneletVisitInformation",
                                   "Object passed as input for the forEachSuccessor function of the routing graph")
-      .add_property("lanelet", &LaneletVisitInformation::lanelet, "the currently visited lanelet")
-      .add_property("predecessor", &LaneletVisitInformation::predecessor, "the predecessor within the shortest path")
-      .add_property("length", &LaneletVisitInformation::length,
+      .def_readwrite("lanelet", &LaneletVisitInformation::lanelet, "the currently visited lanelet")
+      .def_readwrite("predecessor", &LaneletVisitInformation::predecessor, "the predecessor within the shortest path")
+      .def_readwrite("length", &LaneletVisitInformation::length,
                     "The length of the shortest path to this lanelet (including lanelet")
-      .add_property("cost", &LaneletVisitInformation::cost, "The cost along the shortest path")
-      .add_property("numLaneChanges", &LaneletVisitInformation::numLaneChanges,
+      .def_readwrite("cost", &LaneletVisitInformation::cost, "The cost along the shortest path")
+      .def_readwrite("numLaneChanges", &LaneletVisitInformation::numLaneChanges,
                     "The number of lane changes necessary along the shortest path");
 
   class_<LaneletOrAreaVisitInformation>(
       "LaneletOrAreaVisitInformation",
       "Object passed as input for the forEachSuccessorIncludingAreas function of the routing graph")
-      .add_property("laneletOrArea", &LaneletOrAreaVisitInformation::laneletOrArea,
+      .def_readwrite("laneletOrArea", &LaneletOrAreaVisitInformation::laneletOrArea,
                     "the currently visited lanelet/area")
-      .add_property("predecessor", &LaneletOrAreaVisitInformation::predecessor,
+      .def_readwrite("predecessor", &LaneletOrAreaVisitInformation::predecessor,
                     "the predecessor within the shortest path")
-      .add_property("length", &LaneletOrAreaVisitInformation::length,
+      .def_readwrite("length", &LaneletOrAreaVisitInformation::length,
                     "The length of the shortest path to this lanelet (including lanelet")
-      .add_property("cost", &LaneletOrAreaVisitInformation::cost, "The cost along the shortest path")
-      .add_property("numLaneChanges", &LaneletOrAreaVisitInformation::numLaneChanges,
+      .def_readwrite("cost", &LaneletOrAreaVisitInformation::cost, "The cost along the shortest path")
+      .def_readwrite("numLaneChanges", &LaneletOrAreaVisitInformation::numLaneChanges,
                     "The number of lane changes necessary along the shortest path");
 
   class_<RoutingGraph, boost::noncopyable, RoutingGraphPtr>(
@@ -226,8 +226,8 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
            (arg("throwOnError") = true));
 
   class_<LaneletRelation>("LaneletRelation")
-      .add_property("lanelet", &LaneletRelation::lanelet)
-      .add_property("relationType", &LaneletRelation::relationType);
+      .def_readwrite("lanelet", &LaneletRelation::lanelet)
+      .def_readwrite("relationType", &LaneletRelation::relationType);
 
   enum_<RelationType>("RelationType")
       .value("Successor", RelationType::Successor)

--- a/lanelet2_python/python_api/traffic_rules.cpp
+++ b/lanelet2_python/python_api/traffic_rules.cpp
@@ -59,7 +59,7 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
       .add_property("speedLimit", getVelocity, setVelocity, "velocity in km/h")
       .add_property("speedLimitKmH", getVelocity, setVelocity, "velocity in km/h")
       .add_property("speedLimitMPS", getVelocityMPS, setVelocityMPS, "velocity in m/s")
-      .add_property("isMandatory", &SpeedLimitInformation::isMandatory,
+      .def_readwrite("isMandatory", &SpeedLimitInformation::isMandatory,
                     "True if speedlimit is not just a recommendation")
       .def(self_ns::str(self_ns::self));
 


### PR DESCRIPTION
Hi!

Currently, the Lanelet2 python interface uses add_property to expose public struct member variables. This leads to [read-only access](https://www.boost.org/doc/libs/1_61_0/libs/python/doc/html/tutorial/tutorial/exposing.html#tutorial.exposing.class_properties). An example is the `ArcCoordinates` class whose attributes are read-only. 

Here I propose a fix that exposes all public struct member variables in the python interface with read-write access. It may not make practical sense for all classes, but is at least consistent.

Thanks!