### PR TITLE
use TYPED_TEST_SUITE instead of TYPED_TEST_CASE to suppress deprecated warnings

### DIFF
--- a/lanelet2_core/test/test_linestring.cpp
+++ b/lanelet2_core/test/test_linestring.cpp
@@ -152,16 +152,16 @@ using HybridLineStrings = testing::Types<ConstHybridLineString2d, ConstHybridLin
 
 using BasicLineStrings = testing::Types<BasicLineString2d, BasicLineString3d>;
 
-TYPED_TEST_CASE(TwoDPointsTest, TwoDPoints);
-TYPED_TEST_CASE(AllLineStringsTest, AllLineStrings);
-TYPED_TEST_CASE(TwoDLineStringsTest, TwoDLineStrings);
-TYPED_TEST_CASE(ThreeDLineStringsTest, ThreeDLineStrings);
-TYPED_TEST_CASE(NormalLineStringsTest, NormalLineStrings);
-TYPED_TEST_CASE(MutableLineStringsTest, MutableLineStrings);
-TYPED_TEST_CASE(PrimitiveLineStringsTest, PrimitiveLineStrings);
-TYPED_TEST_CASE(NonHybridLineStringsTest, NonHybridLineStrings);
-TYPED_TEST_CASE(HybridLineStringsTest, HybridLineStrings);
-TYPED_TEST_CASE(BasicLineStringsTest, BasicLineStrings);
+TYPED_TEST_SUITE(TwoDPointsTest, TwoDPoints);
+TYPED_TEST_SUITE(AllLineStringsTest, AllLineStrings);
+TYPED_TEST_SUITE(TwoDLineStringsTest, TwoDLineStrings);
+TYPED_TEST_SUITE(ThreeDLineStringsTest, ThreeDLineStrings);
+TYPED_TEST_SUITE(NormalLineStringsTest, NormalLineStrings);
+TYPED_TEST_SUITE(MutableLineStringsTest, MutableLineStrings);
+TYPED_TEST_SUITE(PrimitiveLineStringsTest, PrimitiveLineStrings);
+TYPED_TEST_SUITE(NonHybridLineStringsTest, NonHybridLineStrings);
+TYPED_TEST_SUITE(HybridLineStringsTest, HybridLineStrings);
+TYPED_TEST_SUITE(BasicLineStringsTest, BasicLineStrings);
 
 TYPED_TEST(MutableLineStringsTest, id) {  // NOLINT
   this->ls1.setId(100);

--- a/lanelet2_core/test/test_polygon.cpp
+++ b/lanelet2_core/test/test_polygon.cpp
@@ -205,17 +205,17 @@ using HybridPolygons =
     testing::Types<ConstHybridPolygon2d, ConstHybridPolygon3d, CompoundHybridPolygon2d, CompoundHybridPolygon3d>;
 using HybridPolygonsTwoD = testing::Types<ConstHybridPolygon2d, CompoundHybridPolygon2d>;
 
-TYPED_TEST_CASE(AllPolygonsTest, AllPolygons);
-TYPED_TEST_CASE(TwoDPolygonsTest, TwoDPolygons);
-TYPED_TEST_CASE(ThreeDPolygonsTest, ThreeDPolygons);
-TYPED_TEST_CASE(TwoDAndBasicPolygonsTest, TwoDAndBasicPolygons);
-TYPED_TEST_CASE(ThreeDAndBasicPolygonsTest, ThreeDAndBasicPolygons);
-TYPED_TEST_CASE(NormalPolygonsTest, NormalPolygons);
-TYPED_TEST_CASE(MutablePolygonsTest, MutablePolygons);
-TYPED_TEST_CASE(PrimitivePolygonsTest, PrimitivePolygons);
-TYPED_TEST_CASE(NonHybridPolygonsTest, NonHybridPolygons);
-TYPED_TEST_CASE(HybridPolygonsTest, HybridPolygons);
-TYPED_TEST_CASE(HybridPolygonsTwoDTest, HybridPolygonsTwoD);
+TYPED_TEST_SUITE(AllPolygonsTest, AllPolygons);
+TYPED_TEST_SUITE(TwoDPolygonsTest, TwoDPolygons);
+TYPED_TEST_SUITE(ThreeDPolygonsTest, ThreeDPolygons);
+TYPED_TEST_SUITE(TwoDAndBasicPolygonsTest, TwoDAndBasicPolygons);
+TYPED_TEST_SUITE(ThreeDAndBasicPolygonsTest, ThreeDAndBasicPolygons);
+TYPED_TEST_SUITE(NormalPolygonsTest, NormalPolygons);
+TYPED_TEST_SUITE(MutablePolygonsTest, MutablePolygons);
+TYPED_TEST_SUITE(PrimitivePolygonsTest, PrimitivePolygons);
+TYPED_TEST_SUITE(NonHybridPolygonsTest, NonHybridPolygons);
+TYPED_TEST_SUITE(HybridPolygonsTest, HybridPolygons);
+TYPED_TEST_SUITE(HybridPolygonsTwoDTest, HybridPolygonsTwoD);
 
 TYPED_TEST(MutablePolygonsTest, id) {  // NOLINT
   this->poly1.setId(100);

--- a/lanelet2_routing/test/test_route.cpp
+++ b/lanelet2_routing/test/test_route.cpp
@@ -65,7 +65,7 @@ using AllRoutes =
                    RouteSolidDashedWithAdjacent, RouteSplittedDiverging, RouteSplittedDivergingAndMerging,
                    RouteViaSimple, RouteMissingLanelet, RouteInCircle, RouteCircular, RouteCircularNoLc>;
 
-TYPED_TEST_CASE(AllRoutesTest, AllRoutes);
+TYPED_TEST_SUITE(AllRoutesTest, AllRoutes);
 
 TYPED_TEST(AllRoutesTest, CheckValidity) { EXPECT_NO_THROW(this->route.checkValidity()); }  // NOLINT
 

--- a/lanelet2_routing/test/test_routing_map.h
+++ b/lanelet2_routing/test/test_routing_map.h
@@ -521,7 +521,7 @@ template <typename T>
 class AllGraphsTest : public T {};
 
 using AllGraphs = testing::Types<GermanVehicleGraph, GermanPedestrianGraph, GermanBicycleGraph>;
-TYPED_TEST_CASE(AllGraphsTest, AllGraphs);
+TYPED_TEST_SUITE(AllGraphsTest, AllGraphs);
 }  // namespace tests
 }  // namespace routing
 }  // namespace lanelet


### PR DESCRIPTION
This PR fix build warnings as follows:
```
In file included from /opt/ros/galactic/src/gtest_vendor/include/gtest/gtest.h:71,
                 from 
.../lanelet2/lanelet2_routing/test/test_routing_graph_container.cpp:1:
/opt/ros/galactic/src/gtest_vendor/include/gtest/gtest-typed-test.h:227:64: warning: ‘constexpr bool testing::internal::TypedTestCaseIsDeprecated()’ is deprecated: TYPED_TEST_CASE is deprecated, please use TYPED_TEST_SUITE [-Wdeprecated-declarations]
  227 |   static_assert(::testing::internal::TypedTestCaseIsDeprecated(), ""); \

My Environment
OS: Ubuntu20.04
ROS: ROS2 Galactic