### PR TITLE
Add contribution section to readme and contribution guide  

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,7 +170,7 @@ jobs:
           docker rm -f lanelet2_test_${{ matrix.rosdistro }}_lcov;
 
       - name: Report code coverage
-        uses: immel-f/github-actions-report-lcov@v0.1.9
+        uses: immel-f/github-actions-report-lcov@v0.1.10
         if: ${{ matrix.rosdistro == 'noetic' }}
         with:
           coverage-files: ./lcov/full_coverage.lcov

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,7 +170,7 @@ jobs:
           docker rm -f lanelet2_test_${{ matrix.rosdistro }}_lcov;
 
       - name: Report code coverage
-        uses: immel-f/github-actions-report-lcov@v0.1.10
+        uses: immel-f/github-actions-report-lcov@v0.1.11
         if: ${{ matrix.rosdistro == 'noetic' }}
         with:
           coverage-files: ./lcov/full_coverage.lcov

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+## How to contribute to Lanelet2
+
+#### **Did you find a bug?**
+
+* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues).
+
+* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/new). Be sure to include a **title and clear description**, as much relevant information as possible, and a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
+
+#### **Did you write a patch that fixes a bug?**
+
+* Open a new GitHub pull request with the patch.
+
+* Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+
+#### **Do you intend to add a new feature or change an existing one?**
+
+* Open a new GitHub pull request with feature or change.
+
+* Ensure the PR description clearly describes the added feature or change and the reasoning behind it. Include the relevant issue number if applicable.
+
+#### **Do you have questions about the source code?**
+
+* You can find general info about the structure of Lanelet2 in the [documentation](https://github.com/fzi-forschungszentrum-informatik/Lanelet2#documentation). If you are stuck while implementing a contribution, you can search in the [Issues](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues) or [open a new one](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/new).
+
+Lanelet2 as an open source project welcomes contributions. We encourage you to pitch in!
+
+Thanks! 
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@
 
 #### **Do you have questions about the source code?**
 
-* You can find general info about the structure of Lanelet2 in the [documentation](https://github.com/fzi-forschungszentrum-informatik/Lanelet2#documentation). If you are stuck while implementing a contribution, you can search in the [Issues](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues) or [open a new one](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/new).
+* You can find general info about the structure of Lanelet2 in the [documentation](#documentation). If you are stuck while implementing a contribution, you can search in the [Issues](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues) or [open a new one](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/new).
 
 Lanelet2 as an open source project welcomes contributions. You can find possible open issues for contribution [here](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/contribute). We encourage you to pitch in!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@
 
 * You can find general info about the structure of Lanelet2 in the [documentation](https://github.com/fzi-forschungszentrum-informatik/Lanelet2#documentation). If you are stuck while implementing a contribution, you can search in the [Issues](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues) or [open a new one](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/issues/new).
 
-Lanelet2 as an open source project welcomes contributions. We encourage you to pitch in!
+Lanelet2 as an open source project welcomes contributions. You can find possible open issues for contribution [here](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/contribute). We encourage you to pitch in!
 
 Thanks! 
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Examples and common use cases in both C++ and Python can be found [here](lanelet
 ## Contributing
 
 We encourage you to contribute to Lanelet2! Please check out the
-[Contributing to Lanelet2 guide](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/blob/master/CONTRIBUTING.md) for guidelines about how to proceed. You can find possible open issues for contribution [here](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/contribute).
+[Contributing to Lanelet2 guide](CONTRIBUTING.md) for guidelines about how to proceed. You can find possible open issues for contribution [here](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/contribute).
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,11 @@ Examples and common use cases in both C++ and Python can be found [here](lanelet
 * **lanelet2_validation** provides checks to ensure a valid lanelet2 map
 * **lanelet2_examples** contains tutorials for working with Lanelet2 in C++ and Python
 
+## Contributing
+
+We encourage you to contribute to Lanelet2! Please check out the
+[Contributing to Lanelet2 guide](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/blob/master/CONTRIBUTING.md) for guidelines about how to proceed. You can find possible open issues for contribution [here](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/contribute).
+
 ## Citation
 
 If you are using Lanelet2 for scientific research, we would be pleased if you would cite our [publication](http://www.mrt.kit.edu/z/publ/download/2018/Poggenhans2018Lanelet2.pdf):


### PR DESCRIPTION
I think it would be nice to have a small contribution guide for people who want to contribute something to Lanelet2.  In Github you can mark issues as "good first issue" and then they show up [here](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/contribute). We can open issues for possible contributions and then they are linked to from the readme and the contribution guide. 

@poggenhans @m-naumann  Do you have any feedback or things you want to add to the guide?