### PR TITLE
Improve python core module

### DIFF
--- a/lanelet2_python/python_api/core.cpp
+++ b/lanelet2_python/python_api/core.cpp
@@ -5,6 +5,11 @@
 #include <lanelet2_core/primitives/LaneletSequence.h>
 #include <lanelet2_core/primitives/RegulatoryElement.h>
 
+#include <boost/python/return_by_value.hpp>
+
+#include "lanelet2_core/Attribute.h"
+#include "lanelet2_core/Forward.h"
+#include "lanelet2_core/primitives/Area.h"
 #include "lanelet2_python/internal/converter.h"
 
 using namespace boost::python;
@@ -205,8 +210,10 @@ class IsPrimitive : public def_visitor<IsPrimitive<PrimT>> {
   template <typename ClassT>
   void visit(ClassT& c) const {
     const AttributeMap& (PrimT::*attr)() const = &PrimT::attributes;
-    c.add_property("id", &PrimT::id, &PrimT::setId);
-    c.add_property("attributes", getRefFunc(attr), setAttributeWrapper<PrimT>);
+    c.add_property("id", &PrimT::id, &PrimT::setId,
+                   "Unique ID of this primitive. 0 is a special value for temporary objects.");
+    c.add_property("attributes", getRefFunc(attr), setAttributeWrapper<PrimT>,
+                   "The attributes of this primitive as key value types. Behaves like a dictionary.");
     c.def(self == self);  // NOLINT
     c.def(self != self);  // NOLINT
     c.def(self_ns::str(self_ns::self));
@@ -222,9 +229,10 @@ class IsConstPrimitive : public def_visitor<IsConstPrimitive<PrimT>> {
  public:
   template <typename ClassT>
   void visit(ClassT& c) const {
-    c.add_property("id", &PrimT::id);
+    c.add_property("id", &PrimT::id, "Unique ID of this primitive. 0 is a special value for temporary objects.");
     const AttributeMap& (PrimT::*attr)() const = &PrimT::attributes;
-    c.add_property("attributes", getRefFunc(attr));
+    c.add_property("attributes", getRefFunc(attr),
+                   "The attributes of this primitive as key value types. Behaves like a dictionary.");
     c.def(self == self);  // NOLINT
     c.def(self != self);  // NOLINT
     c.def(self_ns::str(self_ns::self));
@@ -240,7 +248,10 @@ class IsConstLineString : public def_visitor<IsConstLineString<LsT, InternalRef>
  public:
   template <typename ClassT>
   void visit(ClassT& c) const {
-    c.def("__iter__", iterator<LsT>()).def("__len__", &LsT::size).def("inverted", &LsT::inverted);
+    c.def("__iter__", iterator<LsT>())
+        .def("__len__", &LsT::size, "Number of points in this linestring")
+        .def("__iter__", iterator<LsT>())
+        .def("inverted", &LsT::inverted, "Returns whether this is an inverted linestring");
     addGetitem<InternalRef>(c);
   }
   template <bool InternalRefVal, typename ClassT>
@@ -265,10 +276,10 @@ class IsLineString : public def_visitor<IsLineString<LsT>> {
   void visit(ClassT& c) const {
     c.def("__setitem__", wrappers::setItem<LsT, typename LsT::PointType>)
         .def("__delitem__", wrappers::delItem<LsT>)
-        .def("append", &LsT::push_back)
+        .def("append", &LsT::push_back, "Appends a new point at the end of this linestring", arg("point"))
         .def("__iter__", iterator<LsT>())
-        .def("__len__", &LsT::size)
-        .def("inverted", &LsT::inverted);
+        .def("__len__", &LsT::size, "Number of points in this linestring")
+        .def("inverted", &LsT::inverted, "Returns whether this an inverted linestring");
     addGetitem(c);
   }
   template <typename ClassT>
@@ -288,8 +299,7 @@ class IsHybridMap : public def_visitor<IsHybridMap<T>> {
         .def(map_indexing_suite<T, true>())
         .def("keys", MapItem<T>::keys)
         .def("values", MapItem<T>::values)
-        .def("items", MapItem<T>::items,
-             "Iterates over the key-value pairs")
+        .def("items", MapItem<T>::items, "Iterates over the key-value pairs")
         .def(self == self)   // NOLINT
         .def(self != self);  // NOLINT
   }
@@ -332,16 +342,19 @@ auto wrapLayer(const char* layerName) {
   auto search = static_cast<typename LayerT::PrimitiveVec (LayerT::*)(const BoundingBox2d&)>(&LayerT::search);
   auto nearest =
       static_cast<typename LayerT::PrimitiveVec (LayerT::*)(const BasicPoint2d&, unsigned)>(&LayerT::nearest);
-  return class_<LayerT, boost::noncopyable, ClassArgs...>(layerName, no_init)
-      .def("exists", &LayerT::exists, "Checks if a point exists")
-      .def("get", get, "Gets a point with specified Id")
-      .def("__iter__", iterator<LayerT>())
-      .def("__len__", &LayerT::size)
+  return class_<LayerT, boost::noncopyable, ClassArgs...>(layerName,
+                                                          "Primitive layer in a LaneletMap and LaneletSubmap", no_init)
+      .def("exists", &LayerT::exists, arg("id"), "Checks if a point ID exists")
+      .def("__contains__", &LayerT::exists, arg("id"), "Checks if a point ID exists")
+      .def("get", get, arg("id"), "Gets an element with specified Id")
+      .def("__iter__", iterator<LayerT>(), "Iterate elements in this layer in arbitrary order")
+      .def("__len__", &LayerT::size, "Number of items in this layer")
       .def(
-          "__getitem__", +[](LayerT& self, Id idx) { return self.get(idx); })
-      .def("search", search, "Search in a search area")
-      .def("nearest", nearest, "Get nearest n points")
-      .def("uniqueId", &LayerT::uniqueId);
+          "__getitem__", +[](LayerT& self, Id idx) { return self.get(idx); }, arg("id"),
+          "Retrieve an element by its ID")
+      .def("search", search, arg("boundingBox"), "Search in a search area defined by a 2D bounding box")
+      .def("nearest", nearest, (arg("point"), arg("n") = 1), "Gets a list of the nearest n primitives to a given point")
+      .def("uniqueId", &LayerT::uniqueId, "Retrieve an ID that not yet used in this layer");
 }
 
 template <typename PrimT>
@@ -420,17 +433,21 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
       .def("__div__", divWrapper<BasicPoint3d, double>)
       .def(self_ns::str(self_ns::self));
 
-  class_<BoundingBox2d>("BoundingBox2d", init<BasicPoint2d, BasicPoint2d>("BoundingBox2d(minPoint, maxPoint"))
+  class_<BoundingBox2d>(
+      "BoundingBox2d", init<BasicPoint2d, BasicPoint2d>((arg("min"), arg("max")),
+                                                        "Initialize box with its minimum point and its maximum corner"))
       .add_property(
-          "min", +[](BoundingBox2d& self) { return self.min(); })
+          "min", +[](BoundingBox2d& self) { return self.min(); }, "Minimum corner")
       .add_property(
-          "max", +[](BoundingBox2d& self) { return self.max(); });
+          "max", +[](BoundingBox2d& self) { return self.max(); }, "Maximum corner");
 
-  class_<BoundingBox3d>("BoundingBox3d", init<BasicPoint3d, BasicPoint3d>("BoundingBox3d(minPoint, maxPoint"))
+  class_<BoundingBox3d>(
+      "BoundingBox3d", init<BasicPoint3d, BasicPoint3d>((arg("min"), arg("max")),
+                                                        "Initialize box with its minimum point and its maximum corner"))
       .add_property(
-          "min", +[](BoundingBox3d& self) { return self.min(); })
+          "min", +[](BoundingBox3d& self) { return self.min(); }, "Minimum corner")
       .add_property(
-          "max", +[](BoundingBox3d& self) { return self.max(); });
+          "max", +[](BoundingBox3d& self) { return self.max(); }, "Maximum corner");
 
   boost::python::to_python_converter<Attribute, AttributeToPythonStr>();
 
@@ -486,6 +503,7 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
   VectorToListConverter<std::vector<std::shared_ptr<const RightOfWay>>>();
   VectorToListConverter<std::vector<std::shared_ptr<const AllWayStop>>>();
   VectorToListConverter<std::vector<std::string>>();
+  VectorToListConverter<Ids>();
   AttributeFromPythonStr();
   DictToAttributeMapConverter();
 
@@ -531,6 +549,7 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
       .fromPython<LineStrings2d>()
       .fromPython<Polygons2d>()
       .fromPython<Polygons3d>()
+      .fromPython<InnerBounds>()
       .fromPython<Lanelets>()
       .fromPython<ConstLanelets>()
       .fromPython<LaneletsWithStopLines>()
@@ -552,22 +571,33 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
   implicitly_convertible<ConstLanelet, ConstLaneletOrArea>();
   implicitly_convertible<ConstArea, ConstLaneletOrArea>();
 
-  class_<AttributeMap>("AttributeMap", init<>("AttributeMap()"))
+  class_<AttributeMap>("AttributeMap", "Stores attributes as key-value pairs. Behaves similar to a dict.",
+                       init<>("Create an empty attriute map"))
       .def(IsHybridMap<AttributeMap>())
       .def(self_ns::str(self_ns::self));
 
-  class_<RuleParameterMap>("RuleParameterMap", init<>("RuleParameterMap()")).def(IsHybridMap<RuleParameterMap>());
+  class_<RuleParameterMap>("RuleParameterMap",
+                           "Used by RegulatoryElement. Works like a dictionary that maps roles (strings) to a list of "
+                           "primitives with that role (parameters).",
+                           init<>("Create empty rule parameter map"))
+      .def(IsHybridMap<RuleParameterMap>());
 
   class_<ConstRuleParameterMap>("ConstRuleParameterMap", init<>("ConstRuleParameterMap()"))
       .def(IsHybridMap<ConstRuleParameterMap>());
-  class_<ConstPoint2d>("ConstPoint2d", no_init)
+  class_<ConstPoint2d>("ConstPoint2d",
+                       "Immutable 2D point primitive. It can not be instanciated from python but is returned from a "
+                       "few lanelet2 algorithms",
+                       no_init)
       .def(IsConstPrimitive<ConstPoint2d>())
       .add_property("x", getXWrapper<ConstPoint2d>, "x coordinate")
       .add_property("y", getYWrapper<ConstPoint2d>, "y coordinate")
-      .def("basicPoint", &ConstPoint2d::basicPoint, return_internal_reference<>());
+      .def("basicPoint", &ConstPoint2d::basicPoint, return_internal_reference<>(),
+           "Returns a plain 2D point primitive (no ID, no attributes) for efficient geometry operations");
 
   class_<Point2d, bases<ConstPoint2d>>(
-      "Point2d", "Lanelets 2d point primitive",
+      "Point2d",
+      "Lanelets 2d point primitive. Directly convertible to a 3D point, because it is just a 2D view on the existing "
+      "3D data. Use lanelet2.geometry.to3D for this.",
       init<Id, BasicPoint3d, AttributeMap>((arg("id"), arg("point"), arg("attributes") = AttributeMap())))
       .def(init<>("Point2d()"))
       .def(init<Point3d>("Point3d()"))
@@ -577,18 +607,24 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
       .add_property("y", getYWrapper<Point2d>, setYWrapper<Point2d>, "y coordinate")
       .def(IsPrimitive<Point2d>());
 
-  class_<ConstPoint3d>("ConstPoint3d", no_init)
+  class_<ConstPoint3d>("ConstPoint3d",
+                       "Immutable 3D point primitive. It can not be instanciated from python but is returned from a "
+                       "few lanelet2 algorithms",
+                       no_init)
       .def(IsConstPrimitive<ConstPoint3d>())
       .add_property("x", getXWrapper<ConstPoint3d>, "x coordinate")
       .add_property("y", getYWrapper<ConstPoint3d>, "y coordinate")
       .add_property("z", getZWrapper<ConstPoint3d>, "z coordinate")
-      .def("basicPoint", &ConstPoint3d::basicPoint, return_internal_reference<>());
+      .def("basicPoint", &ConstPoint3d::basicPoint, return_internal_reference<>(),
+           "Returns a plain 3D point primitive (no ID, no attributes) for efficient geometry operations");
 
   class_<Point3d, bases<ConstPoint3d>>(
-      "Point3d", "Lanelets 3d point primitive",
+      "Point3d",
+      "Lanelets 3D point primitive. Directly convertible to a 2D point, which shares the same view on the data. Use "
+      "lanelet2.geometry.to2D for this.",
       init<Id, BasicPoint3d, AttributeMap>((arg("id"), arg("point"), arg("attributes") = AttributeMap())))
-      .def(init<>("Point3d()"))
-      .def(init<Point2d>("Point2d()"))
+      .def(init<>("Create an 3D point with ID 0 (invalid ID) at the origin"))
+      .def(init<Point2d>("Create a point from a 2D point"))
       .def(init<Id, double, double, double, AttributeMap>(
           (arg("id"), arg("x"), arg("y"), arg("z") = 0., arg("attributes") = AttributeMap())))
       .add_property("x", getXWrapper<Point3d>, setXWrapper<Point3d>, "x coordinate")
@@ -598,71 +634,108 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
 
   class_<GPSPoint, std::shared_ptr<GPSPoint>>("GPSPoint", "A raw GPS point", no_init)
       .def("__init__", make_constructor(
+                           // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
                            +[](double lat, double lon, double alt) {
                              return std::make_shared<GPSPoint>(GPSPoint({lat, lon, alt}));
                            },
                            default_call_policies(), (arg("lat") = 0., arg("lon") = 0., arg("alt") = 0)))
-      .def_readwrite("lat", &GPSPoint::lat)
-      .def_readwrite("lon", &GPSPoint::lon)
-      .def_readwrite("alt", &GPSPoint::ele);
+      .def_readwrite("lat", &GPSPoint::lat, "Latitude according to WGS84")
+      .def_readwrite("lon", &GPSPoint::lon, "Longitude according to WGS84")
+      .def_readwrite("alt", &GPSPoint::ele, "Elevation according to WGS84 [m]");
 
-  class_<ConstLineString2d>("ConstLineString2d", "Immutable 2d lineString primitive",
-                            init<ConstLineString3d>("ConstLineString2d(ConstLineString3d)"))
-      .def("invert", &ConstLineString2d::invert)
+  class_<ConstLineString2d>(
+      "ConstLineString2d",
+      "Immutable 2d lineString primitive. Behaves similar to a list of points. They cannot be created directly, but "
+      "are returned by some lanelet2 functions. Create mutable Linestring3d instead.",
+      init<ConstLineString3d>("Create (immutable) 2D Linestring from 3D linestring", (args("linestring"))))
+      .def("invert", &ConstLineString2d::invert,
+           "Creates a new, inverted linestring from this. This is essentially a view on the existing data, with points "
+           "returned in reversed order")
       .def(IsConstLineString<ConstLineString2d>())
       .def(IsConstPrimitive<ConstLineString2d>());
 
   class_<LineString2d, bases<ConstLineString2d>>(
-      "LineString2d", "Lanelets 2d lineString primitive",
-      init<Id, Points3d, AttributeMap>("LineString2d(id, point_list, attributes)"))
-      .def(init<Id, Points3d>("LineString2d(id, point_list"))
-      .def(init<LineString3d>("LineString2d(LineString3d)"))
-      .def("invert", &LineString2d::invert)
+      "LineString2d",
+      "Lanelet2s 2D linestring primitive. Has an ID, attributes and points with linear iterpolation in between the "
+      "points. Easily convertible to a 3D linestring, "
+      "because it is essentially a view on "
+      "the same 3D data. Use lanelet2.geometry.to3D for this.",
+      init<Id, Points3d, AttributeMap>("Create a linestring from an ID, a list of 3D points and attributes",
+                                       (arg("id"), arg("point3d"), arg("attributes"))))
+      .def(init<Id, Points3d>("Create a linestring from an ID and a list of 3D points", (arg("id"), arg("points3d"))))
+      .def(init<LineString3d>("Returns a 3D linestring for the current data. Both share the same data, modifications "
+                              "affect both linestrings."))
+      .def("invert", &LineString2d::invert,
+           "Creates a new, inverted linestring from this. This is essentially a view on the existing data, with points "
+           "returned in reversed order")
       .def(IsLineString<LineString2d>());
 
-  class_<ConstLineString3d>("ConstLineString3d", "Immutable 3d lineString primitive",
-                            init<ConstLineString2d>("ConstLineString3d(ConstLineString2d)"))
+  class_<ConstLineString3d>("ConstLineString3d",
+                            "Immutable 3d lineString primitive. They cannot be created directly, but "
+                            "are returned by some lanelet2 functions. Create mutable Linestring3d instead. Use "
+                            "lanelet2.geometry.to2D to convert to 2D pendant.",
+                            init<ConstLineString2d>("Convert 2d linestring to 3D linestring"))
       .def(init<Id, Points3d, AttributeMap>((arg("id"), arg("points"), arg("attributes") = AttributeMap())))
-      .def("invert", &ConstLineString3d::invert)
+      .def("invert", &ConstLineString3d::invert,
+           "Creates a new, inverted linestring from this. This is essentially a view on the existing data, with points "
+           "returned in reversed order")
       .def(IsConstLineString<ConstLineString3d>())
       .def(IsConstPrimitive<ConstLineString3d>());
 
   class_<LineString3d, bases<ConstLineString3d>>(
-      "LineString3d", "Lanelets 3d lineString primitive",
-      init<Id, Points3d, AttributeMap>((arg("id"), arg("points"), arg("attributes") = AttributeMap())))
-      .def(init<LineString2d>("LineString3d(LineString2d)"))
-      .def("invert", &LineString3d::invert)
+      "LineString3d",
+      "Lanelets 3d lineString primitive. Has an ID, attribtues and points. Accessing individual points works similar "
+      "to python lists. Create mutable Linestring3d instead. Use lanelet2.geometry.to2D to convert to Linestring2d."
+      "convert to Linestring2d.",
+      init<Id, Points3d, AttributeMap>((arg("id") = 0, arg("points") = Points3d{}, arg("attributes") = AttributeMap())))
+      .def(init<LineString2d>(arg("linestring"),
+                              "Converts a 2D linestring to a 3D linestring, sharing the same underlying data."))
+      .def("invert", &LineString3d::invert,
+           "Creates a new, inverted linestring from this. This is essentially a view on the existing data, with points "
+           "returned in reversed order")
       .def(IsLineString<LineString3d>())
       .def(IsPrimitive<LineString3d>());
 
-  class_<ConstHybridLineString2d>("ConstHybridLineString2d", "A Linestring that behaves like a normal BasicLineString",
-                                  init<LineString2d>("ConstHybridLineString2d(LineString2d"))
-      .def(init<ConstLineString2d>())
-      .def("invert", &ConstHybridLineString2d::invert)
+  class_<ConstHybridLineString2d>(
+      "ConstHybridLineString2d",
+      "A 2D Linestring that behaves like a normal BasicLineString (i.e. returns BasicPoints), "
+      "but still has an ID and attributes.",
+      init<ConstLineString2d>(arg("linestring"), "Create from a 2D linestring"))
+      .def("invert", &ConstHybridLineString2d::invert,
+           "Creates a new, inverted linestring from this. This is essentially a view on the existing data, with points "
+           "returned in reversed order")
       .def(IsConstLineString<ConstHybridLineString2d, false>())
       .def(IsConstPrimitive<ConstHybridLineString2d>());
 
-  class_<ConstHybridLineString3d>("ConstHybridLineString3d", "A Linestring that behaves like a normal BasicLineString",
-                                  init<LineString3d>("ConstHybridLineString3d(LineString3d"))
-      .def("invert", &ConstHybridLineString3d::invert)
+  class_<ConstHybridLineString3d>(
+      "ConstHybridLineString3d",
+      "A 3D Linestring that behaves like a normal BasicLineString (i.e. returns BasicPoints), "
+      "but still has an ID and attributes.",
+      init<ConstLineString3d>(arg("linestring"), "Create from a 3D linestring"))
+      .def("invert", &ConstHybridLineString3d::invert,
+           "Creates a new, inverted linestring from this. This is essentially a view on the existing data, with points "
+           "returned in reversed order")
       .def(IsConstLineString<ConstHybridLineString3d, false>())
       .def(IsConstPrimitive<ConstHybridLineString3d>());
 
-  class_<CompoundLineString2d>("CompoundLineString2d", "A LineString composed of multiple linestrings",
-                               init<ConstLineStrings2d>())
+  class_<CompoundLineString2d>("CompoundLineString2d",
+                               "A LineString composed of multiple linestrings (i.e. it provides access to the points "
+                               "in these linestrings in order)",
+                               init<ConstLineStrings2d>(arg("linestrings"), "Create from a list of LineString2d"))
       .def(IsConstLineString<CompoundLineString2d>())
-      .def("lineStrings", &CompoundLineString2d::lineStrings)
-      .def("ids", &CompoundLineString2d::ids, "ids of the linestrings");
+      .def("lineStrings", &CompoundLineString2d::lineStrings, "The linestrings that this linestring consists of")
+      .def("ids", &CompoundLineString2d::ids, "List of the IDs of the linestrings");
 
   class_<CompoundLineString3d>("CompoundLineString3d", "A LineString composed of multiple linestrings",
-                               init<ConstLineStrings3d>())
+                               init<ConstLineStrings3d>(arg("linestrings"), "Create from a list of LineString3d"))
       .def(IsConstLineString<CompoundLineString3d>())
-      .def("lineStrings", &CompoundLineString3d::lineStrings)
-      .def("ids", &CompoundLineString3d::ids, "ids of the linestrings");
+      .def("lineStrings", &CompoundLineString3d::lineStrings, "The linestrings that this linestring consists of")
+      .def("ids", &CompoundLineString3d::ids, "List of the IDs of the linestrings");
 
   class_<ConstPolygon2d>(
       "ConstPolygon2d", "A two-dimensional lanelet polygon",
-      init<Id, Points3d, AttributeMap>((arg("id"), arg("points"), arg("attributes") = AttributeMap())))
+      init<Id, Points3d, AttributeMap>((arg("id"), arg("points"), arg("attributes") = AttributeMap()),
+                                       "Create from an ID, a list of points and optionally attributes"))
       .def(IsConstLineString<ConstPolygon2d>())
       .def(IsConstPrimitive<ConstPolygon2d>());
 
@@ -672,51 +745,68 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
       .def(IsConstLineString<ConstPolygon3d>())
       .def(IsConstPrimitive<ConstPolygon3d>());
 
-  class_<Polygon2d, bases<ConstPolygon2d>>("Polygon2d", "A two-dimensional lanelet polygon",
-                                           init<Id, Points3d, AttributeMap>("Polygon2d(Id, point_list, attributes"))
+  class_<Polygon2d, bases<ConstPolygon2d>>(
+      "Polygon2d",
+      "A two-dimensional lanelet polygon. Points in clockwise order and open (i.e. start point != end point).",
+      init<Id, Points3d, AttributeMap>((arg("id"), arg("points"), arg("attributes") = AttributeMap()),
+                                       "Create from an ID, the boundary points and (optionally) attributes"))
       .def(IsLineString<Polygon2d>())
       .def(IsPrimitive<Polygon2d>());
 
   class_<Polygon3d, bases<ConstPolygon3d>>(
-      "Polygon3d", "A three-dimensional lanelet polygon",
+      "Polygon3d",
+      "A two-dimensional lanelet polygon. Points in clockwise order and open (i.e. start point != end point).",
       init<Id, Points3d, AttributeMap>((arg("id"), arg("points"), arg("attributes") = AttributeMap())))
       .def(IsLineString<Polygon3d>())
       .def(IsPrimitive<Polygon3d>());
 
-  class_<CompoundPolygon2d>("CompoundPolygon2d", "A polygon composed of multiple linestrings",
-                            init<ConstLineStrings2d>())
+  class_<CompoundPolygon2d>(
+      "CompoundPolygon2d", "A 2D polygon composed of multiple linestrings",
+      init<ConstLineStrings2d>(arg("linestrings"),
+                               "Create a compound polygon from a list of linestrings (in clockwise order)"))
       .def(IsConstLineString<CompoundPolygon2d>())
-      .def("lineStrings", &CompoundPolygon2d::lineStrings)
-      .def("ids", &CompoundPolygon2d::ids, "ids of the linestrings");
+      .def("lineStrings", &CompoundPolygon2d::lineStrings, "The linestrings in this polygon")
+      .def("ids", &CompoundPolygon2d::ids, "List of the ids of the linestrings");
 
-  class_<CompoundPolygon3d>("CompoundPolygon3d", "A polygon composed of multiple linestrings",
+  class_<CompoundPolygon3d>("CompoundPolygon3d", "A 3D polygon composed of multiple linestrings",
                             init<ConstLineStrings3d>())
       .def(IsConstLineString<CompoundPolygon3d>())
-      .def("lineStrings", &CompoundPolygon3d::lineStrings)
-      .def("ids", &CompoundPolygon3d::ids, "ids of the linestrings");
+      .def("lineStrings", &CompoundPolygon3d::lineStrings, "The linestrings in this polygon")
+      .def("ids", &CompoundPolygon3d::ids, "List of the ids of the linestrings");
 
-  class_<ConstLanelet>("ConstLanelet", "An immutable lanelet primitive",
-                       init<Id, LineString3d, LineString3d, AttributeMap>(
-                           (arg("id"), arg("leftBound"), arg("rightBound"), arg("attributes") = AttributeMap())))
-      .def(init<Lanelet>())
+  class_<ConstLanelet>(
+      "ConstLanelet",
+      "An immutable lanelet primitive. Consist of a left and right boundary, attributes and a set of "
+      "traffic rules that apply here. It is not very useful within python, but returned by some lanelet2 algorihms",
+      init<Id, LineString3d, LineString3d, AttributeMap>(
+          (arg("id"), arg("leftBound"), arg("rightBound"), arg("attributes") = AttributeMap())))
+      .def(init<Lanelet>(arg("lanelet"), "Construct from a mutable lanelet"))
       .def(IsConstPrimitive<ConstLanelet>())
-      .add_property("centerline", &ConstLanelet::centerline, "Centerline of the lanelet")
-      .add_property("leftBound", &ConstLanelet::leftBound, "Left boundary of lanelet")
-      .add_property("rightBound", &ConstLanelet::rightBound, "Right boundary of lanelet")
+      .add_property(
+          "centerline", &ConstLanelet::centerline,
+          "Centerline of the lanelet (immutable). This is usualy calculated on-the-fly from the left and right "
+          "bound. The centerline and all its points have ID 0. The centerline can also be overridden by a custom "
+          "centerline, which will usually have nonzero IDs.")
+      .add_property("leftBound", &ConstLanelet::leftBound, "Left boundary of the lanelet")
+      .add_property("rightBound", &ConstLanelet::rightBound, "Right boundary of the lanelet")
       .add_property("regulatoryElements",
                     make_function(&ConstLanelet::regulatoryElements, return_value_policy<return_by_value>()),
                     "Regulatory elements of the lanelet")
-      .def("trafficLights", constRegelemAs<TrafficLight>, "traffic light regulatory elements")
-      .def("trafficSigns", constRegelemAs<TrafficSign>, "traffic sign regulatory elements")
-      .def("speedLimits", constRegelemAs<SpeedLimit>, "speed limit regulatory elements")
-      .def("rightOfWay", constRegelemAs<RightOfWay>, "right of way regulatory elements")
-      .def("allWayStop", constRegelemAs<AllWayStop>, "all way stop regulatory elements")
+      .def("trafficLights", constRegelemAs<TrafficLight>,
+           "Returns the list of traffic light regulatory elements of this lanelet")
+      .def("trafficSigns", constRegelemAs<TrafficSign>,
+           "Returns a list of traffic sign regulatory elements of this lanelet")
+      .def("speedLimits", constRegelemAs<SpeedLimit>,
+           "Returns a list of speed limit regulatory elements of this lanelet")
+      .def("rightOfWay", constRegelemAs<RightOfWay>, "Returns right of way regulatory elements of this lanelet")
+      .def("allWayStop", constRegelemAs<AllWayStop>, "Returns all way stop regulatory elements of this lanelet")
       .def("invert", &ConstLanelet::invert, "Returns inverted lanelet (flipped left/right bound, etc")
       .def("inverted", &ConstLanelet::inverted, "Returns whether this lanelet has been inverted")
       .def("polygon2d", &ConstLanelet::polygon2d, "Outline of this lanelet as 2d polygon")
       .def("polygon3d", &ConstLanelet::polygon3d, "Outline of this lanelet as 3d polygon")
       .def("resetCache", &ConstLanelet::resetCache,
-           "Reset the cache. Forces update of the centerline if points have chagned");
+           "Reset the cache. Forces update of the centerline if points have changed. This does not clear a custom "
+           "centerline.");
 
   auto left = static_cast<LineString3d (Lanelet::*)()>(&Lanelet::leftBound);
   auto right = static_cast<LineString3d (Lanelet::*)()>(&Lanelet::rightBound);
@@ -725,115 +815,159 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
   class_<Lanelet, bases<ConstLanelet>>(
       "Lanelet", "The famous lanelet primitive",
       init<Id, LineString3d, LineString3d, AttributeMap>(
-          (arg("id"), arg("leftBound"), arg("rightBound"), arg("attributes") = AttributeMap())))
+          (arg("id"), arg("leftBound"), arg("rightBound"), arg("attributes") = AttributeMap()),
+          "Create Lanelet from an ID, its left and right boundary and (optionally) attributes"))
       .def(IsPrimitive<Lanelet>())
-      .add_property("centerline", &Lanelet::centerline, &Lanelet::setCenterline, "Centerline of the lanelet")
-      .add_property("leftBound", left, &Lanelet::setLeftBound, "Left boundary of lanelet")
-      .add_property("rightBound", right, &Lanelet::setRightBound, "Right boundary of lanelet")
+      .add_property(
+          "centerline", &Lanelet::centerline, &Lanelet::setCenterline,
+          "Centerline of the lanelet (immutable). This is usualy calculated on-the-fly from the left and right "
+          "bound. The centerline and all its points have ID 0. Assigning a linestring will replace this by a custom, "
+          "persistent centerline.")
+      .add_property("leftBound", left, &Lanelet::setLeftBound, "Left boundary of the lanelet")
+      .add_property("rightBound", right, &Lanelet::setRightBound, "Right boundary of the lanelet")
       .add_property("regulatoryElements", make_function(regelems, return_value_policy<return_by_value>()),
                     "Regulatory elements of the lanelet")
-      .def("trafficLights", regelemAs<TrafficLight>, "traffic light regulatory elements")
-      .def("trafficSigns", regelemAs<TrafficSign>, "traffic sign regulatory elements")
-      .def("speedLimits", regelemAs<SpeedLimit>, "speed limit regulatory elements")
-      .def("rightOfWay", regelemAs<RightOfWay>, "right of way regulatory elements")
-      .def("allWayStop", regelemAs<AllWayStop>, "all way stop regulatory elements")
-      .def("addRegulatoryElement", &Lanelet::addRegulatoryElement)
-      .def("removeRegulatoryElement", &Lanelet::removeRegulatoryElement)
-      .def("invert", &Lanelet::invert, "Returns inverted lanelet (flipped left/right bound, etc")
+      .def("trafficLights", regelemAs<TrafficLight>,
+           "Returns the list of traffic light regulatory elements of this lanelet")
+      .def("trafficSigns", regelemAs<TrafficSign>, "Returns a list of traffic sign regulatory elements of this lanelet")
+      .def("speedLimits", regelemAs<SpeedLimit>, "Returns a list of speed limit regulatory elements of this lanelet")
+      .def("rightOfWay", regelemAs<RightOfWay>, "Returns right of way regulatory elements of this lanelet")
+      .def("allWayStop", regelemAs<AllWayStop>, "Returns all way stop regulatory elements of this lanelet")
+      .def("addRegulatoryElement", &Lanelet::addRegulatoryElement, arg("regelem"),
+           "Adds a new regulatory element to the lanelet")
+      .def("removeRegulatoryElement", &Lanelet::removeRegulatoryElement, arg("regelem"),
+           "Removes a regulatory element from the lanelet, returns true on success")
+      .def("invert", &Lanelet::invert, "Returns inverted lanelet (flipped left/right bound, etc)")
       .def("inverted", &ConstLanelet::inverted, "Returns whether this lanelet has been inverted")
-      .def("polygon2d", &ConstLanelet::polygon2d, "Outline of this lanelet as 2d polygon")
-      .def("polygon3d", &ConstLanelet::polygon3d, "Outline of this lanelet as 3d polygon");
+      .def("polygon2d", &ConstLanelet::polygon2d, "Outline of this lanelet as 2D polygon")
+      .def("polygon3d", &ConstLanelet::polygon3d, "Outline of this lanelet as 3D polygon");
 
   class_<LaneletSequence>("LaneletSequence", "A combined lane formed from multiple lanelets", init<ConstLanelets>())
-      .add_property("centerline", &LaneletSequence::centerline, "Centerline of the lanelet")
-      .add_property("leftBound", &LaneletSequence::leftBound, "Left boundary of lanelet")
-      .add_property("rightBound", &LaneletSequence::rightBound, "Right boundary of lanelet")
-      .def("invert", &LaneletSequence::invert, "Returns inverted lanelet (flipped left/right bound, etc")
-      .def("inverted", &LaneletSequence::inverted, "Returns whether this lanelet has been inverted")
-      .def("polygon2d", &LaneletSequence::polygon2d, "Outline of this lanelet as 2d polygon")
-      .def("polygon3d", &LaneletSequence::polygon3d, "Outline of this lanelet as 3d polygon")
-      .def("lanelets", &LaneletSequence::lanelets, "Lanelets that make up this compound lanelet")
+      .add_property("centerline", &LaneletSequence::centerline, "Centerline of the combined lanelets")
+      .add_property("leftBound", &LaneletSequence::leftBound, "Left boundary of the combined lanelets")
+      .add_property("rightBound", &LaneletSequence::rightBound, "Right boundary of the combined lanelets")
+      .def("invert", &LaneletSequence::invert, "Returns inverted lanelet sequence (flipped left/right bound, etc)")
+      .def("polygon2d", &LaneletSequence::polygon2d, "Outline of this lanelet as 2D polygon")
+      .def("polygon3d", &LaneletSequence::polygon3d, "Outline of this lanelet as 3D polygon")
+      .def("lanelets", &LaneletSequence::lanelets, "Lanelets that make up this lanelet sequence")
       .def("__iter__", iterator<LaneletSequence>())
-      .def("__len__", &LaneletSequence::size)
-      .def("inverted", &LaneletSequence::inverted)
-      .def("__getitem__", wrappers::getItem<LaneletSequence>, return_internal_reference<>());
+      .def("__len__", &LaneletSequence::size, "Number of lanelets in this sequence")
+      .def("inverted", &LaneletSequence::inverted, "True if this lanelet sequence is inverted")
+      .def("__getitem__", wrappers::getItem<LaneletSequence>, return_internal_reference<>(),
+           "Returns a lanelet in the sequence");
 
-  class_<ConstLaneletWithStopLine>("ConstLaneletWithStopLine", "A lanelet with a stopline", no_init)
+  class_<ConstLaneletWithStopLine>("ConstLaneletWithStopLine", "A lanelet with an (optional) stopline", no_init)
       .def("__init__",
-          make_constructor(+[](Lanelet lanelet, Optional<ConstLineString3d> stopLine){
-                              return std::make_shared<ConstLaneletWithStopLine>(
-                                  ConstLaneletWithStopLine{
-                                    std::move(lanelet), std::move(stopLine)
-                                  }
-                              );
-                           },
-          default_call_policies(),
-          (arg("lanelet"), arg("stopLine") = Optional<ConstLineString3d>{})))
-      .add_property("lanelet", &ConstLaneletWithStopLine::lanelet)
+           make_constructor(
+               +[](Lanelet lanelet, Optional<ConstLineString3d> stopLine) {
+                 return std::make_shared<ConstLaneletWithStopLine>(
+                     ConstLaneletWithStopLine{std::move(lanelet), std::move(stopLine)});
+               },
+               default_call_policies(), (arg("lanelet"), arg("stopLine") = Optional<ConstLineString3d>{})),
+           "Construct from a lanelet and a stop line")
+      .add_property("lanelet", &ConstLaneletWithStopLine::lanelet, "The lanelet")
       .add_property(
           "stopLine", +[](const ConstLaneletWithStopLine& self) { return optionalToObject(self.stopLine); },
           +[](ConstLaneletWithStopLine& self, const object& value) {
             self.stopLine = objectToOptional<LineString3d>(value);
-          });
+          },
+          "The stop line for the lanelet (can be None)");
 
   class_<LaneletWithStopLine>("LaneletWithStopLine", "A lanelet with a stopline", no_init)
-      .def("__init__",
-          make_constructor(+[](Lanelet lanelet, Optional<LineString3d> stopLine){
-                              return std::make_shared<LaneletWithStopLine>(
-                                  LaneletWithStopLine{
-                                    std::move(lanelet), std::move(stopLine)
-                                  }
-                              );
+      .def("__init__", make_constructor(
+                           +[](Lanelet lanelet, Optional<LineString3d> stopLine) {
+                             return std::make_shared<LaneletWithStopLine>(
+                                 LaneletWithStopLine{std::move(lanelet), std::move(stopLine)});
                            },
-          default_call_policies(),
-          (arg("lanelet"), arg("stopLine") = Optional<LineString3d>{})))
-      .add_property("lanelet", &LaneletWithStopLine::lanelet)
+                           default_call_policies(), (arg("lanelet"), arg("stopLine") = Optional<LineString3d>{})))
+      .add_property("lanelet", &LaneletWithStopLine::lanelet, "The lanelet")
       .add_property(
           "stopLine", +[](const LaneletWithStopLine& self) { return optionalToObject(self.stopLine); },
           +[](LaneletWithStopLine& self, const object& value) {
             self.stopLine = objectToOptional<LineString3d>(value);
-          });
+          },
+          "The stop line (LineString3d or None)");
 
-  class_<ConstArea>("ConstArea", "Represents an area, potentially with holes, in the map",
-                    boost::python::init<Id, LineStrings3d, InnerBounds, AttributeMap>(
-                        "Lanelet(id, outerBound, innerBounds, attributes"))
-      .def(init<Id, LineStrings3d, InnerBounds>("Lanelet(id, outerBound, innerBounds"))
-      .def(init<Id, LineStrings3d>("Lanelet(id, outerBound"))
+  // areas are a bit complicated because the holes are vectors of vectors. For those, we cannot rely on the automatic
+  // vector-to-list conversion, because area.innerBounds[0].append(ls) would then operate on a temporary list and do
+  // nothing.
+  class_<ConstInnerBounds>("ConstInnerBounds", "An immutable list-like type to hold of inner boundaries of an Area",
+                           no_init)
+      .def("__iter__", iterator<InnerBounds>())
+      .def("__len__", &InnerBounds::size, "Number of holes")
+      .def("__getitem__", wrappers::getItem<ConstInnerBounds>, return_value_policy<return_by_value>());
+
+  class_<InnerBounds>("InnerBounds", "A list-like type to hold of inner boundaries of an Area", no_init)
+      .def("__setitem__", wrappers::setItem<InnerBounds, LineStrings3d>)
+      .def("__delitem__", wrappers::delItem<InnerBounds>)
+      .def(
+          "append", +[](InnerBounds& self, LineStrings3d ls) { self.push_back(std::move(ls)); }, "Appends a new hole",
+          arg("hole"))
+      .def("__iter__", iterator<InnerBounds>())
+      .def("__len__", &InnerBounds::size, "Number of holes")
+      .def("__getitem__", wrappers::getItem<InnerBounds>, return_value_policy<return_by_value>());
+
+  class_<ConstArea>(
+      "ConstArea",
+      "Represents an immutable area, potentially with holes, in the map. It is composed of a list of linestrings that "
+      "form the outer boundary and a list of a list of linestrings that represent holes within it.",
+      boost::python::init<Id, LineStrings3d, InnerBounds, AttributeMap>(
+          (arg("id"), arg("outerBound"), arg("innerBounds") = InnerBounds{}, arg("attributes") = AttributeMap{}),
+          "Construct an area from an ID, its inner and outer boundaries and attributes"))
       .def(IsConstPrimitive<ConstArea>())
-      .add_property("outerBound", &ConstArea::outerBound)
-      .add_property("innerBounds", &ConstArea::innerBounds)
-      .def("outerBoundPolygon", &ConstArea::outerBoundPolygon)
-      .def("innerBoundPolygon", &ConstArea::innerBoundPolygons);
+      .add_property("outerBound", &ConstArea::outerBound,
+                    "The outer boundary, a list of clockwise oriented linestrings")
+      .add_property("innerBounds", &ConstArea::innerBounds,
+                    "The inner boundaries (holes), a list of a list of counter-clockwise oriented linestrings")
+      .add_property(
+          "regulatoryElements", +[](ConstArea& self) { return self.regulatoryElements(); },
+          "The regulatory elements of this area")
+      .def("outerBoundPolygon", &ConstArea::outerBoundPolygon, "Returns the outer boundary as a CompoundPolygon3d")
+      .def("innerBoundPolygon", &ConstArea::innerBoundPolygons,
+           "Returns the inner boundaries as a list of CompoundPolygon3d");
 
-  class_<Area, bases<ConstArea>>("Area", "Represents an area, potentially with holes, in the map",
-                                 boost::python::init<Id, LineStrings3d, InnerBounds, AttributeMap>(
-                                     "Lanelet(id, outerBound, innerBounds, attributes"))
-      .def(init<Id, LineStrings3d, InnerBounds>("Lanelet(id, outerBound, innerBounds"))
-      .def(init<Id, LineStrings3d>("Lanelet(id, outerBound"))
+  class_<Area, bases<ConstArea>>(
+      "Area", "Represents an area, potentially with holes, in the map",
+      boost::python::init<Id, LineStrings3d, InnerBounds, AttributeMap>(
+          (arg("id"), arg("outerBound"), arg("innerBounds") = InnerBounds{}, arg("attributes") = AttributeMap{}),
+          "Construct an area from an ID, its inner and outer boundaries and attributes"))
       .def(IsPrimitive<Area>())
       .add_property(
-          "outerBound", +[](Area& self) { return self.outerBound(); }, &Area::setOuterBound)
+          "outerBound", +[](Area& self) { return self.outerBound(); }, &Area::setOuterBound,
+          "The outer boundary, a list of clockwise oriented linestrings")
       .add_property(
-          "innerBounds", +[](Area& self) { return self.innerBounds(); }, &Area::setInnerBounds)
+          "innerBounds",
+          make_function(
+              // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+              +[](Area& self) -> InnerBounds& { return const_cast<InnerBounds&>(self.innerBounds()); },
+              return_internal_reference<>()),
+          +[](Area& self, const InnerBounds& lss) { self.setInnerBounds(lss); },
+          "The inner boundaries (holes), a list of a list of counter-clockwise oriented linestrings")
       .add_property(
           "regulatoryElements", +[](Area& self) { return self.regulatoryElements(); },
-          "Regulatory elements of the area")
-      .def("addRegulatoryElement", &Area::addRegulatoryElement)
-      .def("removeRegulatoryElement", &Area::removeRegulatoryElement)
-      .def("outerBoundPolygon", &Area::outerBoundPolygon)
-      .def("innerBoundPolygon", &Area::innerBoundPolygons);
+          "The regulatory elements of this area")
+      .def("addRegulatoryElement", &Area::addRegulatoryElement, "Appends a new regulatory element", arg("regelem"))
+      .def("removeRegulatoryElement", &Area::removeRegulatoryElement,
+           "Removes a regulatory element, retunrs true on success", arg("regelem"))
+      .def("outerBoundPolygon", &Area::outerBoundPolygon, "Returns the outer boundary as a CompoundPolygon3d")
+      .def("innerBoundPolygon", &Area::innerBoundPolygons,
+           "Returns the inner boundaries as a list of CompoundPolygon3d");
 
   using GetParamSig = ConstRuleParameterMap (RegulatoryElement::*)() const;
 
   class_<RegulatoryElement, boost::noncopyable, RegulatoryElementPtr>(
-      "RegulatoryElement", "A Regulatory element defines traffic rules that affect a lanelet", no_init)
+      "RegulatoryElement",
+      "A Regulatory element defines traffic rules that affect a lanelet. This is a abstract base class that is "
+      "implemented e.g. by the TrafficLight class.",
+      no_init)
       .def(IsConstPrimitive<RegulatoryElement>())
       .add_property("id", &RegulatoryElement::id, &RegulatoryElement::setId)
       .add_property("parameters", static_cast<GetParamSig>(&RegulatoryElement::getParameters),
-                    "the parameters (ie traffic signs, lanelets) that affect "
+                    "The parameters (ie traffic signs, lanelets) that affect "
                     "this RegulatoryElement")
-      .add_property("roles", &RegulatoryElement::roles)
-      .def("find", &RegulatoryElement::find<ConstRuleParameter>, "Returns a primitive with matching id, else None")
+      .add_property("roles", &RegulatoryElement::roles, "A list of roles (strings) used in this regulatory element")
+      .def("find", &RegulatoryElement::find<ConstRuleParameter>, arg("id"),
+           "Returns a primitive with matching ID, else None")
       .def("__len__", &RegulatoryElement::size);
   register_ptr_to_python<RegulatoryElementConstPtr>();
 
@@ -843,11 +977,17 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
                                         (arg("id"), arg("attributes"), arg("trafficLights"),
                                          arg("stopLine") = Optional<LineString3d>())))
       .add_property(
-          "stopLine", +[](TrafficLight& self) { return self.stopLine(); }, &TrafficLight::setStopLine)
+          "stopLine", +[](TrafficLight& self) { return self.stopLine(); }, &TrafficLight::setStopLine,
+          "The stop line of for this TrafficLight (a LineString or None)")
+      .add_property("removeStopLine", &TrafficLight::removeStopLine, "Clear the stop line")
       .add_property(
-          "trafficLights", +[](TrafficLight& self) { return self.trafficLights(); })
-      .def("addTrafficLight", &TrafficLight::addTrafficLight)
-      .def("removeTrafficLight", &TrafficLight::removeTrafficLight);
+          "trafficLights", +[](TrafficLight& self) { return self.trafficLights(); },
+          "Traffic lights. Should all have the same phase.")
+      .def("addTrafficLight", &TrafficLight::addTrafficLight,
+           "Add a traffic light. Either a linestring from the left edge to the right edge or an area with the outline "
+           "of the traffic light.")
+      .def("removeTrafficLight", &TrafficLight::removeTrafficLight,
+           "Removes a given traffic light, returns true on success");
   implicitly_convertible<std::shared_ptr<TrafficLight>, RegulatoryElementPtr>();
 
   enum_<ManeuverType>("ManeuverType")
@@ -858,81 +998,122 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
 
   class_<RightOfWay, boost::noncopyable, std::shared_ptr<RightOfWay>, bases<RegulatoryElement>>(
       "RightOfWay", "A right of way regulatory element", no_init)
-      .def("__init__", make_constructor(&RightOfWay::make, default_call_policies(),
-                                        (arg("id"), arg("attributes"), arg("rightOfWayLanelets"), arg("yieldLanelets"),
-                                         arg("stopLine") = Optional<LineString3d>{})))
+      .def("__init__",
+           make_constructor(&RightOfWay::make, default_call_policies(),
+                            (arg("id"), arg("attributes"), arg("rightOfWayLanelets"), arg("yieldLanelets"),
+                             arg("stopLine") = Optional<LineString3d>{})),
+           "Creates a right of way regulatory element with an ID from attributes, the list lanelets with right of way, "
+           "the list of yielding lanelets and an optional stop line")
       .add_property(
-          "stopLine", +[](RightOfWay& self) { return self.stopLine(); }, &RightOfWay::setStopLine)
-      .def("removeStopLine", &RightOfWay::removeStopLine)
-      .def("getManeuver", &RightOfWay::getManeuver, "get maneuver for a lanelet")
+          "stopLine", +[](RightOfWay& self) { return self.stopLine(); }, &RightOfWay::setStopLine,
+          "The stop line (can be None)")
+      .def("removeStopLine", &RightOfWay::removeStopLine, "Clear the stop line")
+      .def("getManeuver", &RightOfWay::getManeuver, "Get maneuver for a lanelet")
       .def(
-          "rightOfWayLanelets", +[](RightOfWay& self) { return self.rightOfWayLanelets(); })
-      .def("addRightOfWayLanelet", &RightOfWay::addRightOfWayLanelet)
-      .def("removeRightOfWayLanelet", &RightOfWay::removeRightOfWayLanelet)
+          "rightOfWayLanelets", +[](RightOfWay& self) { return self.rightOfWayLanelets(); },
+          "Returns the lanelets that have the right of way")
+      .def("addRightOfWayLanelet", &RightOfWay::addRightOfWayLanelet, arg("lanelet"),
+           "Add another Lanelet that has the right of way. The Lanelet should also reference this regulatory element.")
+      .def("removeRightOfWayLanelet", &RightOfWay::removeRightOfWayLanelet, arg("lanelet"),
+           "Removes the right of way for this lanelet, returns true on success.")
       .def(
           "yieldLanelets", +[](RightOfWay& self) { return self.yieldLanelets(); })
-      .def("addYieldLanelet", &RightOfWay::addYieldLanelet)
-      .def("removeYieldLanelet", &RightOfWay::removeYieldLanelet);
+      .def("addYieldLanelet", &RightOfWay::addYieldLanelet, arg("lanelet"),
+           "Adds another lanelet that has to yield. The lanelet should also reference this regolatory element.")
+      .def("removeYieldLanelet", &RightOfWay::removeYieldLanelet, arg("lanelet"),
+           "Removes the yielding lanelet, returns true on success.");
   implicitly_convertible<std::shared_ptr<RightOfWay>, RegulatoryElementPtr>();
 
   class_<AllWayStop, boost::noncopyable, std::shared_ptr<AllWayStop>, bases<RegulatoryElement>>(
       "AllWayStop", "An all way stop regulatory element", no_init)
-      .def("__init__", make_constructor(&AllWayStop::make, default_call_policies(),
-                                        (arg("id"), arg("attributes"), arg("lltsWithStop"),
-                                         arg("signs") = LineStringsOrPolygons3d{})))
+      .def("__init__",
+           make_constructor(
+               &AllWayStop::make, default_call_policies(),
+               (arg("id"), arg("attributes"), arg("lltsWithStop"), arg("signs") = LineStringsOrPolygons3d{})),
+           "Constructs an all way stop regulatory element with an ID and attributes from a list of lanelets with their "
+           "(optional) stop line and an optional list of traffic signs for this rule")
       .def(
-          "lanelets", +[](AllWayStop& self) { return self.lanelets(); })
+          "lanelets", +[](AllWayStop& self) { return self.lanelets(); }, "Returns the lanelets")
       .def(
-          "stopLines", +[](AllWayStop& self) { return self.stopLines(); })
+          "stopLines", +[](AllWayStop& self) { return self.stopLines(); },
+          "Returns the stop lines (same order as the lanelets)")
       .def(
-          "trafficSigns", +[](AllWayStop& self) { return self.trafficSigns(); })
-      .def("addTrafficSign", &AllWayStop::addTrafficSign)
-      .def("removeTrafficSign", &AllWayStop::removeTrafficSign)
-      .def("addLanelet", &AllWayStop::addLanelet)
-      .def("removeLanelet", &AllWayStop::removeLanelet);
+          "trafficSigns", +[](AllWayStop& self) { return self.trafficSigns(); },
+          "Returns the list of traffic signs for this rule")
+      .def("addTrafficSign", &AllWayStop::addTrafficSign, arg("sign"),
+           "Adds another traffic sign (a Linestring3d from their left to the right edge or a Polygon3d with the "
+           "outline)")
+      .def("removeTrafficSign", &AllWayStop::removeTrafficSign, arg("sign"),
+           "Removes a traffic sign, returns True on success")
+      .def("addLanelet", &AllWayStop::addLanelet, arg("lanelet"),
+           "Adds another lanelet to the all way stop. The lanelet should also reference this all way stop.")
+      .def("removeLanelet", &AllWayStop::removeLanelet, arg("lanelet"),
+           "Removes a lanelet from the all way stop, returns True on success.");
   implicitly_convertible<std::shared_ptr<AllWayStop>, RegulatoryElementPtr>();
 
-  class_<TrafficSignsWithType, std::shared_ptr<TrafficSignsWithType>>("TrafficSignsWithType", no_init)
+  class_<TrafficSignsWithType, std::shared_ptr<TrafficSignsWithType>>(
+      "TrafficSignsWithType", "Combines a traffic sign with its type, used for the TrafficSign regulatory element",
+      no_init)
       .def("__init__", make_constructor(+[](LineStringsOrPolygons3d ls) {
              return std::make_shared<TrafficSignsWithType>(TrafficSignsWithType{std::move(ls)});
-           }))
+           }),
+           "Construct from a Linestring/Polygon with a type deduced from the attributes.")
       .def("__init__", make_constructor(+[](LineStringsOrPolygons3d ls, std::string type) {
              return std::make_shared<TrafficSignsWithType>(TrafficSignsWithType{std::move(ls), std::move(type)});
-           }))
+           }),
+           "Construct from a Linestring/Polygon with an explicit type")
       .def_readwrite("trafficSigns", &TrafficSignsWithType::trafficSigns)
       .def_readwrite("type", &TrafficSignsWithType::type);
 
   class_<TrafficSign, boost::noncopyable, std::shared_ptr<TrafficSign>, bases<RegulatoryElement>>(
-      "TrafficSign", "A traffic sign regulatory element", no_init)
-      .def("__init__", make_constructor(&TrafficSign::make, default_call_policies(),
-                                        (arg("id"), arg("attributes"), arg("trafficSigns"),
-                                         arg("cancellingTrafficSigns") = TrafficSignsWithType{},
-                                         arg("refLines") = LineStrings3d(), arg("cancelLines") = LineStrings3d())))
+      "TrafficSign", "A generic traffic sign regulatory element", no_init)
+      .def("__init__",
+           make_constructor(&TrafficSign::make, default_call_policies(),
+                            (arg("id"), arg("attributes"), arg("trafficSigns"),
+                             arg("cancellingTrafficSigns") = TrafficSignsWithType{}, arg("refLines") = LineStrings3d(),
+                             arg("cancelLines") = LineStrings3d())),
+           "Constructs a traffic sign withan ID and attributes from a traffic signs with type object and optionally "
+           "cancelling traffic signs, lines from where the rule starts and lines where it ends")
       .def(
-          "trafficSigns", +[](TrafficSign& self) { return self.trafficSigns(); })
+          "trafficSigns", +[](TrafficSign& self) { return self.trafficSigns(); },
+          "Get a list of all traffic signs (linestrings or polygons)")
       .def(
-          "cancellingTrafficSigns", +[](TrafficSign& self) { return self.cancellingTrafficSigns(); })
+          "cancellingTrafficSigns", +[](TrafficSign& self) { return self.cancellingTrafficSigns(); },
+          "Get a list of all cancelling traffic signs (linestrings or polygons). These are the signs that mark the end "
+          "of a rule. E.g. a sign that cancels a speed limit.")
       .def(
-          "refLines", +[](TrafficSign& self) { return self.refLines(); })
+          "refLines", +[](TrafficSign& self) { return self.refLines(); },
+          "List of linestrings after which the traffic rule becomes valid")
       .def(
-          "cancelLines", +[](TrafficSign& self) { return self.cancelLines(); })
-      .def("addTrafficSign", &TrafficSign::addTrafficSign)
-      .def("removeTrafficSign", &TrafficSign::removeTrafficSign)
-      .def("addRefLine", &TrafficSign::addRefLine)
-      .def("removeRefLine", &TrafficSign::removeRefLine)
-      .def("addCancellingTrafficSign", &TrafficSign::addCancellingTrafficSign)
-      .def("removeCancellingTrafficSign", &TrafficSign::removeCancellingTrafficSign)
-      .def("addCancellingRefLine", &TrafficSign::addCancellingRefLine)
-      .def("removeCancellingRefLine", &TrafficSign::removeCancellingRefLine)
-      .def("type", &TrafficSign::type)
-      .def("cancelTypes", &TrafficSign::cancelTypes);
+          "cancelLines", +[](TrafficSign& self) { return self.cancelLines(); },
+          "List of linestrings after which the rule becomes invalid")
+      .def("addTrafficSign", &TrafficSign::addTrafficSign, arg("trafficSign"),
+           "Add another traffic sign (linestring or polygon)")
+      .def("removeTrafficSign", &TrafficSign::removeTrafficSign, arg("trafficSign"),
+           "Remove a traffic sign, returns True on success")
+      .def("addRefLine", &TrafficSign::addRefLine, arg("refLine"), "Add a ref line")
+      .def("removeRefLine", &TrafficSign::removeRefLine, arg("refLine"), "Remove a ref line, returns True on success")
+      .def("addCancellingTrafficSign", &TrafficSign::addCancellingTrafficSign, arg("cancellingTrafficSign"),
+           "Add a cancelling traffic sign")
+      .def("removeCancellingTrafficSign", &TrafficSign::removeCancellingTrafficSign, arg("cancellingTrafficSign"),
+           "Remove cancelling traffic sign, return True on success")
+      .def("addCancellingRefLine", &TrafficSign::addCancellingRefLine, arg("cancelLine"), "Add a cancelling ref line")
+      .def("removeCancellingRefLine", &TrafficSign::removeCancellingRefLine, arg("cancelLine"),
+           "Remove a cancelling ref line, returns True on success")
+      .def("type", &TrafficSign::type,
+           "Returns the type (string) of the traffic sign that start this rule. This is deduced from the traffic sign "
+           "itself or "
+           "the explicitly set type. All signs are assumed to have the same type.")
+      .def("cancelTypes", &TrafficSign::cancelTypes,
+           "Returns types of the cancelling traffic signs (a list of strings) if it exists.");
 
   implicitly_convertible<std::shared_ptr<TrafficSign>, RegulatoryElementPtr>();
 
   implicitly_convertible<std::shared_ptr<SpeedLimit>, RegulatoryElementPtr>();
 
   class_<SpeedLimit, boost::noncopyable, std::shared_ptr<SpeedLimit>, bases<TrafficSign>>(  // NOLINT
-      "SpeedLimit", "A speed limit regulatory element", no_init)
+      "SpeedLimit", "A speed limit regulatory element. This is a special case of a traffic sign regulatory element.",
+      no_init)
       .def("__init__", make_constructor(&TrafficSign::make, default_call_policies(),
                                         (arg("id"), arg("attributes"), arg("trafficSigns"),
                                          arg("cancellingTrafficSigns") = TrafficSignsWithType{},
@@ -943,65 +1124,114 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
 
   wrapLayer<AreaLayer, bases<PrimitiveLayer<Area>>>("AreaLayer")
       .def(
-          "findUsages", +[](AreaLayer& self, RegulatoryElementPtr& e) { return self.findUsages(e); })
+          "findUsages", +[](AreaLayer& self, RegulatoryElementPtr& e) { return self.findUsages(e); }, arg("regElem"),
+          "Find areas with this regulatory element")
       .def(
-          "findUsages", +[](AreaLayer& self, ConstLineString3d& ls) { return self.findUsages(ls); });
+          "findUsages", +[](AreaLayer& self, ConstLineString3d& ls) { return self.findUsages(ls); }, arg("ls"),
+          "Find areas with this linestring");
   wrapLayer<LaneletLayer, bases<PrimitiveLayer<Lanelet>>>("LaneletLayer")
       .def(
-          "findUsages", +[](LaneletLayer& self, RegulatoryElementPtr& e) { return self.findUsages(e); })
+          "findUsages", +[](LaneletLayer& self, RegulatoryElementPtr& e) { return self.findUsages(e); }, arg("regElem"),
+          "Find lanelets with this regualtory element")
       .def(
-          "findUsages", +[](LaneletLayer& self, ConstLineString3d& ls) { return self.findUsages(ls); });
+          "findUsages", +[](LaneletLayer& self, ConstLineString3d& ls) { return self.findUsages(ls); }, arg("ls"),
+          "Lanelets with this linestring");
   wrapLayer<PolygonLayer>("PolygonLayer")
       .def(
-          "findUsages", +[](PolygonLayer& self, ConstPoint3d& p) { return self.findUsages(p); });
+          "findUsages", +[](PolygonLayer& self, ConstPoint3d& p) { return self.findUsages(p); }, arg("point"),
+          "Find polygons with this point");
   wrapLayer<LineStringLayer>("LineStringLayer")
       .def(
-          "findUsages", +[](LineStringLayer& self, ConstPoint3d& p) { return self.findUsages(p); });
+          "findUsages", +[](LineStringLayer& self, ConstPoint3d& p) { return self.findUsages(p); }, arg("point"),
+          "Find linestrings with this point");
   wrapLayer<PointLayer>("PointLayer");
   wrapLayer<RegulatoryElementLayer>("RegulatoryElementLayer");
 
   class_<LaneletMapLayers, boost::noncopyable>("LaneletMapLayers", "Container for the layers of a lanelet map")
-      .def_readonly("laneletLayer", &LaneletMap::laneletLayer, "Lanelets")
-      .def_readonly("areaLayer", &LaneletMap::areaLayer)
-      .def_readonly("regulatoryElementLayer", &LaneletMap::regulatoryElementLayer)
-      .def_readonly("lineStringLayer", &LaneletMap::lineStringLayer)
-      .def_readonly("polygonLayer", &LaneletMap::polygonLayer)
-      .def_readonly("pointLayer", &LaneletMap::pointLayer);
+      .def_readonly("laneletLayer", &LaneletMap::laneletLayer,
+                    "Lanelets of this map (works like a dictionary with ID as key and Lanelet as value)")
+      .def_readonly("areaLayer", &LaneletMap::areaLayer,
+                    "Areas of this map (works like a dictionary with ID as key and Area as value)")
+      .def_readonly(
+          "regulatoryElementLayer", &LaneletMap::regulatoryElementLayer,
+          "Regulatory elements of this map (works like a dictionary with ID as key and RegulatoryElement as value)")
+      .def_readonly("lineStringLayer", &LaneletMap::lineStringLayer,
+                    "Linestrings of this map (works like a dictionary with ID as key and Linestring3d as value)")
+      .def_readonly("polygonLayer", &LaneletMap::polygonLayer,
+                    "Polygons of this map (works like a dictionary with ID as key and Polygon3d as value)")
+      .def_readonly("pointLayer", &LaneletMap::pointLayer,
+                    "Points of this map (works like a dictionary with ID as key and Point3d as value)");
 
   class_<LaneletMap, bases<LaneletMapLayers>, LaneletMapPtr, boost::noncopyable>(
-      "LaneletMap", "Object for managing a lanelet map", init<>("LaneletMap()"))
-      .def("add", selectAdd<Point3d>())
-      .def("add", selectAdd<Lanelet>())
-      .def("add", selectAdd<Area>())
-      .def("add", selectAdd<LineString3d>())
-      .def("add", selectAdd<Polygon3d>())
-      .def("add", selectAdd<const RegulatoryElementPtr&>());
+      "LaneletMap",
+      "A lanelet map collects lanelet primitives. It can be used for writing and loading and creating routing graphs. "
+      "It also offers geometrical and relational queries for its objects. Note that this is not the right object for "
+      "querying neigborhood relations. Create a lanelet2.routing.RoutingGraph for this.\nNote that there is a utility "
+      "function 'createMapFromX' to create a map from a list of primitives.",
+      init<>("Create an empty lanelet map"))
+      .def("add", selectAdd<Point3d>(), arg("point"),
+           "Add a point to the map. It its ID is zero, it will be set to a unique value.")
+      .def("add", selectAdd<Lanelet>(), arg("lanelet"),
+           "Add a lanelet and all its subobjects to the map. It its (or its subobjects IDs) are zero, it will be set "
+           "to a unique value.")
+      .def("add", selectAdd<Area>(), arg("area"),
+           "Add an area and all its subobjects to the map. It its (or its subobjects IDs) are zero, it will be set to "
+           "a unique value.")
+      .def("add", selectAdd<LineString3d>(), arg("linestring"),
+           "Add a linestring and all its points to the map. It its (or its points IDs) are zero, it will be set to a "
+           "unique value.")
+      .def("add", selectAdd<Polygon3d>(), arg("polygon"),
+           "Add a polygon and all its points to the map. It its (or its points IDs) are zero, it will be set to a "
+           "unique value.")
+      .def("add", selectAdd<const RegulatoryElementPtr&>(), arg("regelem"),
+           "Add a regulatory element and all its subobjects to the map. It its (or its subobjects IDs) are zero, it "
+           "will be set to a unique value.");
   register_ptr_to_python<LaneletMapConstPtr>();
 
   class_<LaneletSubmap, bases<LaneletMapLayers>, LaneletSubmapPtr, boost::noncopyable>(
-      "LaneletSubmap", "Object for managing parts of a lanelet map", init<>("LaneletSubmap()"))
+      "LaneletSubmap",
+      "A submap manages parts of a lanelet map. An important difference is that adding an object to the map will *not* "
+      "add its subobjects too, making it more efficient to create. Apart from that, it offers a similar functionality "
+      "compared to a lanelet map.",
+      init<>("Create an empty lanelet submap"))
       .def(
-          "laneletMap", +[](LaneletSubmap& self) { return LaneletMapPtr{self.laneletMap()}; })
-      .def("add", selectSubmapAdd<Point3d>())
-      .def("add", selectSubmapAdd<Lanelet>())
-      .def("add", selectSubmapAdd<Area>())
-      .def("add", selectSubmapAdd<LineString3d>())
-      .def("add", selectSubmapAdd<Polygon3d>())
-      .def("add", selectSubmapAdd<const RegulatoryElementPtr&>());
+          "laneletMap", +[](LaneletSubmap& self) { return LaneletMapPtr{self.laneletMap()}; },
+          "Create a lanelet map of this submap that also holds all subobjects. This is a potentially costly operation.")
+      .def("add", selectSubmapAdd<Point3d>(), arg("point"), "Add a point to the submap")
+      .def("add", selectSubmapAdd<Lanelet>(), arg("lanelet"),
+           "Add a lanelet to the submap, without its subobjects. If its ID is zero it will be set to a unique value "
+           "instead.")
+      .def("add", selectSubmapAdd<Area>(), arg("area"),
+           "Add an area to the submap, without its subobjects. If its ID is zero it will be set to a unique value "
+           "instead.")
+      .def("add", selectSubmapAdd<LineString3d>(), arg("linestring"),
+           "Add a linesting to the submap, without its points. If its ID is zero it will be set to a unique value "
+           "instead.")
+      .def("add", selectSubmapAdd<Polygon3d>(), arg("polygon"),
+           "Add a polygon to the submap, without its points. If its ID is zero it will be set to a unique value "
+           "instead.")
+      .def("add", selectSubmapAdd<const RegulatoryElementPtr&>(), arg("regelem"),
+           "Add a regulatory element to the submap, without its subobjects. If its ID is zero it will be set to a "
+           "unique value "
+           "instead.");
   register_ptr_to_python<LaneletSubmapConstPtr>();
 
-  def("getId", static_cast<Id (&)()>(utils::getId), "Returns a unique id");
-  def("registerId", &utils::registerId, "Registers an id");
+  def("getId", static_cast<Id (&)()>(utils::getId), "Returns a globally unique id");
+  def("registerId", &utils::registerId, "Registers an id (so that it will not be returned by getId)");
 
-  def("createMapFromPoints", createMapWrapper<Points3d>, "Create map from primitives");
-  def("createMapFromLineStrings", createMapWrapper<LineStrings3d>, "Create map from primitives");
-  def("createMapFromPolygons", createMapWrapper<Polygons3d>, "Create map from primitives");
-  def("createMapFromLanelets", createMapWrapper<Lanelets>, "Create map from primitives");
-  def("createMapFromAreas", createMapWrapper<Areas>, "Create map from primitives");
+  def("createMapFromPoints", createMapWrapper<Points3d>, arg("points"), "Create map from a list of points");
+  def("createMapFromLineStrings", createMapWrapper<LineStrings3d>, arg("linestrings"),
+      "Create map from a list of linestrings");
+  def("createMapFromPolygons", createMapWrapper<Polygons3d>, arg("polygons"), "Create map from a list of polygons");
+  def("createMapFromLanelets", createMapWrapper<Lanelets>, arg("lanelets"), "Create map from a list of lanelets");
+  def("createMapFromAreas", createMapWrapper<Areas>, arg("areas"), "Create map from a list of areas");
 
-  def("createSubmapFromPoints", createSubmapWrapper<Points3d>, "Create sbumap from primitives");
-  def("createSubmapFromLineStrings", createSubmapWrapper<LineStrings3d>, "Create submap from primitives");
-  def("createSubmapFromPolygons", createSubmapWrapper<Polygons3d>, "Create submap from primitives");
-  def("createSubmapFromLanelets", createSubmapWrapper<Lanelets>, "Create submap from primitives");
-  def("createSubmapFromAreas", createSubmapWrapper<Areas>, "Create submap from primitives");
+  def("createSubmapFromPoints", createSubmapWrapper<Points3d>, arg("points"), "Create sbumap from a list of points");
+  def("createSubmapFromLineStrings", createSubmapWrapper<LineStrings3d>, arg("linestrings"),
+      "Create submap from a list of linestrings");
+  def("createSubmapFromPolygons", createSubmapWrapper<Polygons3d>, arg("polygons"),
+      "Create submap from a list of polygons");
+  def("createSubmapFromLanelets", createSubmapWrapper<Lanelets>, arg("lanelets"),
+      "Create submap from a list of lanelets");
+  def("createSubmapFromAreas", createSubmapWrapper<Areas>, arg("areas"), "Create submap from a list of areas");
 }


### PR DESCRIPTION
This PR is part 1 of my effort to make our python bindings more intuitive to use. More PRs will follow whenever I find the time. This PR adds:
- (more or less) meaningful docstrings to all classes, methods and attributes in core
- `__repr__` methods to all core primitives (e.g. `print(linestring)` now shows sth like `LineString3d(0, [Point3d(0, 1, 0, 0), Point3d(1, 0, 1, 0)], AttributeMap({'subtype': 'de220'}))` instead of useless garbage.
- meaningful argument names so that e.g. lanelets can be initialized with kwargs: `Lanelet(id, leftBound=left, rightBound=right)`
- More options to construct objects more easily with more `__init__`s 
- fixes for a few weird bugs e.g. assigning values to inner bounds of Areas did nothing

There are no real functional changes, no ones code should be broken, unless he relied on weird things, e.g. initalizing lanelets with `Lanelet(arg1=id, arg2=left, arg3=right)`.