### PR TITLE
Remove unused local typedefs

### DIFF
--- a/lanelet2_core/include/lanelet2_core/geometry/impl/LineString.h
+++ b/lanelet2_core/include/lanelet2_core/geometry/impl/LineString.h
@@ -127,7 +127,6 @@ BasicPoint3d project(const CompoundHybridLineString3d& lineString, const BasicPo
 template <typename LineStringT, typename PointT>
 std::pair<double, ProjectedPointInfo<traits::BasicPointT<PointT>>> signedDistanceImpl(const LineStringT lineString,
                                                                                       const PointT& p) {
-  using BasicPoint = PointT;
   const auto basicP = utils::toBasicPoint(p);
   const auto nextSegment = closestSegment(lineString, basicP);
   const auto projPoint = lanelet::geometry::project(utils::toBasicSegment(nextSegment), basicP);


### PR DESCRIPTION
Hi, thank you for the work.

remove unused local typedefs to fix the following werror.

```
/opt/ros/humble/include/lanelet2_core/geometry/impl/LineString.h: In function ‘std::pair<double, lanelet::geometry::internal::ProjectedPointInfo<typename lanelet::traits::PointTraits<PointT>::BasicPoint> > lanelet::geometry::internal::signedDistanceImpl(LineStringT, const PointT&)’:
/opt/ros/humble/include/lanelet2_core/geometry/impl/LineString.h:130:9: error: typedef ‘using BasicPoint = PointT’ locally defined but not used [-Werror=unused-local-typedefs]
  130 |   using BasicPoint = PointT;
      |         ^~~~~~~~~~
```

related: https://github.com/fzi-forschungszentrum-informatik/Lanelet2/pull/300