### PR TITLE
Add versioning for Lanelet2 primitives (#1)

### DIFF
--- a/lanelet2_core/include/lanelet2_core/LaneletMap.h
+++ b/lanelet2_core/include/lanelet2_core/LaneletMap.h
@@ -152,6 +152,17 @@ class PrimitiveLayer {
    */
   size_t size() const { return elements_.size(); }
 
+  /**
+   * @brief increments versions for all elements in this layer
+   */
+  void incrementVersions();
+
+  /**
+   * @brief sets target version to all elements in this layer
+   * @param version target version
+   */
+  void setVersions(uint32_t version);
+
   using ConstSearchFunction = std::function<bool(const internal::SearchBoxT<T>& box, const ConstPrimitiveT& prim)>;
   using SearchFunction = std::function<bool(const internal::SearchBoxT<T>& box, const PrimitiveT& prim)>;
 
@@ -540,6 +551,9 @@ void registerId(Id id);
 
 template <typename PrimitiveT>
 std::vector<ConstLayerPrimitive<PrimitiveT>> findUsages(const PrimitiveLayer<PrimitiveT>& layer, Id id);
+
+template <typename PrimitiveT>
+void incrementVersions(const PrimitiveLayer<PrimitiveT>& layer);
 
 ConstLanelets findUsagesInLanelets(const LaneletMapLayers& map, const ConstPoint3d& p);
 ConstAreas findUsagesInAreas(const LaneletMapLayers& map, const ConstPoint3d& p);

--- a/lanelet2_core/include/lanelet2_core/primitives/Lanelet.h
+++ b/lanelet2_core/include/lanelet2_core/primitives/Lanelet.h
@@ -26,8 +26,8 @@ class LaneletData : public PrimitiveData {
    * @see ConstLanelet::ConstLanelet
    */
   LaneletData(Id id, LineString3d leftBound, LineString3d rightBound, const AttributeMap& attributes = AttributeMap(),
-              RegulatoryElementPtrs regulatoryElements = RegulatoryElementPtrs())
-      : PrimitiveData(id, attributes),
+              RegulatoryElementPtrs regulatoryElements = RegulatoryElementPtrs(), uint32_t version = 0)
+      : PrimitiveData(id, attributes, version),
         leftBound_{std::move(leftBound)},
         rightBound_{std::move(rightBound)},
         regulatoryElements_{std::move(regulatoryElements)} {}
@@ -140,11 +140,11 @@ class ConstLanelet : public ConstPrimitive<LaneletData> {
   explicit ConstLanelet(Id id = InvalId)
       : ConstLanelet(std::make_shared<LaneletData>(id, LineString3d(), LineString3d()), false) {}
 
-  //! Constructs a lanelet from id, attributes, regulatoryElements and bounds.
+  //! Constructs a lanelet from id, version, attributes, regulatoryElements, bounds.
   ConstLanelet(Id id, const LineString3d& leftBound, const LineString3d& rightBound,
-               const AttributeMap& attributes = AttributeMap(),
-               const RegulatoryElementPtrs& regulatoryElements = RegulatoryElementPtrs())
-      : ConstPrimitive{std::make_shared<LaneletData>(id, leftBound, rightBound, attributes, regulatoryElements)} {}
+              const AttributeMap& attributes = AttributeMap(),
+              const RegulatoryElementPtrs& regulatoryElements = RegulatoryElementPtrs(), uint32_t version = 0)
+      : ConstPrimitive{std::make_shared<LaneletData>(id, leftBound, rightBound, attributes, regulatoryElements, version)} {}
 
   //! Construct from the data of a different Lanelet
   explicit ConstLanelet(const std::shared_ptr<const LaneletData>& data, bool inverted = false)

--- a/lanelet2_core/include/lanelet2_core/primitives/LineString.h
+++ b/lanelet2_core/include/lanelet2_core/primitives/LineString.h
@@ -139,8 +139,10 @@ struct SelectInsertIterator<typename SelectLsIterator<Point2d>::Iterator> {
 class LineStringData : public PrimitiveData {
  public:
   explicit LineStringData(Id id) : PrimitiveData(id) {}
-  LineStringData(Id id, Points3d points, AttributeMap attributes)
-      : PrimitiveData(id, std::move(attributes)), points_(std::move(points)) {}
+
+  LineStringData(Id id, Points3d points, AttributeMap attributes, uint32_t version = 0)
+      : PrimitiveData(id, std::move(attributes), version), points_(std::move(points)) {}
+
   // NOLINTNEXTLINE
   using iterator = internal::ReverseAndForwardIterator<Points3d::iterator>;
   // NOLINTNEXTLINE
@@ -241,8 +243,8 @@ class ConstLineStringImpl : public ConstPrimitive<LineStringData> {
 
   //! Constructs a LineString or similar from an Id and a list of points
   explicit ConstLineStringImpl(Id id = InvalId, Points3d points = Points3d(),
-                               const AttributeMap& attributes = AttributeMap())
-      : ConstPrimitive{std::make_shared<LineStringData>(id, std::move(points), attributes)} {}
+                               const AttributeMap& attributes = AttributeMap(), uint32_t version = 0)
+      : ConstPrimitive{std::make_shared<LineStringData>(id, std::move(points), attributes, version)} {}
 
   //! Constructs a linestring from the data object of another linestring
   explicit ConstLineStringImpl(const std::shared_ptr<const LineStringData>& data, bool inverted = false)

--- a/lanelet2_core/include/lanelet2_core/primitives/Point.h
+++ b/lanelet2_core/include/lanelet2_core/primitives/Point.h
@@ -102,10 +102,11 @@ struct ArcCoordinates {
 
 //! Common data management class for all Point primitives.
 //! @ingroup DataObjects
-class PointData : public PrimitiveData {  // NOLINT
- public:
-  PointData(Id id, BasicPoint3d point, const AttributeMap& attributes = AttributeMap())
-      : PrimitiveData(id, attributes), point(point), point2d_{point.x(), point.y()} {}
+class PointData : public PrimitiveData {  // NOLINT    
+ public: 
+  PointData(Id id, BasicPoint3d point, const AttributeMap& attributes = AttributeMap(), uint32_t version = 0)
+    : PrimitiveData(id, attributes, version), point(point), point2d_{point.x(), point.y()} {}
+
   PointData(const PointData&) = delete;
   PointData& operator=(const LineStringData&) = delete;
   PointData(PointData&&) = default;
@@ -160,8 +161,8 @@ class ConstPoint2d : public ConstPrimitive<PointData> {
   using ConstPrimitive::ConstPrimitive;
 
   //! @brief Construct from an id and a point
-  ConstPoint2d(Id id, const BasicPoint3d& point, const AttributeMap& attributes = AttributeMap())
-      : ConstPrimitive<PointData>{std::make_shared<PointData>(id, point, attributes)} {}  // NOLINT
+  ConstPoint2d(Id id, const BasicPoint3d& point, const AttributeMap& attributes = AttributeMap(), uint32_t version = 0)
+      : ConstPrimitive<PointData>{std::make_shared<PointData>(id, point, attributes, version)} {}  // NOLINT
 
   //! @brief Construct from an id and coordinates
   /**
@@ -169,9 +170,9 @@ class ConstPoint2d : public ConstPrimitive<PointData> {
    * point, where z matters.
    */
   explicit ConstPoint2d(Id id = InvalId, double x = 0., double y = 0., double z = 0.,
-                        const AttributeMap& attributes = AttributeMap())
+                        const AttributeMap& attributes = AttributeMap(), uint32_t version = 0)
       : ConstPrimitive<PointData>{std::make_shared<PointData>(  // NOLINT
-            id, BasicPoint3d(x, y, z), attributes)} {}
+            id, BasicPoint3d(x, y, z), attributes, version)} {}
 
   //! A ConstPoint 2d is implicitly convertible to a normal 2d point
   operator BasicPoint2d() const noexcept {  // NOLINT

--- a/lanelet2_core/include/lanelet2_core/primitives/Primitive.h
+++ b/lanelet2_core/include/lanelet2_core/primitives/Primitive.h
@@ -39,9 +39,11 @@ class PrimitiveData {
   /**
    * @brief Constructs a PrimitiveData object
    */
-  explicit PrimitiveData(Id id, AttributeMap attributes = AttributeMap()) : id{id}, attributes{std::move(attributes)} {}
+  
+  PrimitiveData(Id id, AttributeMap attributes = AttributeMap(), uint32_t version = 0) : id{id}, attributes{std::move(attributes)}, version{version} {}
 
   Id id{InvalId};           //!< Id of this primitive (unique across one map)
+  uint32_t version{0};           //!< Version of this primitive 
   AttributeMap attributes;  //!< attributes of this primitive
  protected:
   ~PrimitiveData() = default;
@@ -94,6 +96,8 @@ class ConstPrimitive {
    * structure that is not a part of the map.
    */
   Id id() const noexcept { return constData_->id; }
+
+  uint32_t version() const noexcept { return constData_->version; }
 
   //! check whether this primitive has a specific attribute
   bool hasAttribute(const std::string& name) const noexcept { return attributes().find(name) != attributes().end(); }
@@ -268,6 +272,8 @@ class Primitive : public DerivedConstPrimitive {
    * identified by their id. Make sure you know what you are doing!
    */
   void setId(Id id) noexcept { data()->id = id; }
+
+  void setVersion(uint32_t version) noexcept { data()->version = version; }
 
   //! @brief set or overwrite an attribute
   void setAttribute(const std::string& name, const Attribute& attribute) { attributes()[name] = attribute; }

--- a/lanelet2_core/include/lanelet2_core/primitives/RegulatoryElement.h
+++ b/lanelet2_core/include/lanelet2_core/primitives/RegulatoryElement.h
@@ -194,6 +194,8 @@ class RegulatoryElement  // NOLINT
    */
   void setId(Id id) noexcept { data()->id = id; }
 
+  void setVersion(uint32_t version) noexcept { data()->version = version; }
+
   //! Returns all parameters as const object (coversion overhead for const)
   ConstRuleParameterMap getParameters() const;
 

--- a/lanelet2_core/src/LaneletMap.cpp
+++ b/lanelet2_core/src/LaneletMap.cpp
@@ -472,6 +472,46 @@ typename PrimitiveLayer<T>::const_iterator PrimitiveLayer<T>::find(Id id) const 
   return elements_.find(id);
 }
 
+
+/**
+ * @brief This namespace defines function conditionally returning reference: 
+ * - if an argument is a ptr, returns the reference to the object it points to
+ * - if an argument is an object, returns the reference to the object
+ */
+namespace {
+  template <typename T>
+  struct is_shared_ptr : std::false_type{};
+
+  template <typename T>
+  struct is_shared_ptr<std::shared_ptr<T>> : std::true_type{};
+
+  template <typename T>
+  auto getReference(T& object) -> std::enable_if_t<is_shared_ptr<T>::value, decltype(*object)> {
+    return *object;
+  }
+
+  template <typename T>
+  auto getReference(T& object) -> std::enable_if_t<!is_shared_ptr<T>::value, T&> {
+    return object;
+  }
+}
+
+template <typename T>
+void PrimitiveLayer<T>::incrementVersions() {
+  for (auto& pair : elements_) {
+    auto& elem = getReference(pair.second);
+    elem.setVersion(elem.version() + 1);
+  }
+}
+
+template <typename T>
+void PrimitiveLayer<T>::setVersions(uint32_t version) {
+  for (auto& pair : elements_) {
+    auto& elem = getReference(pair.second);
+    elem.setVersion(version);
+  }
+}
+
 template <typename T>
 typename PrimitiveLayer<T>::const_iterator PrimitiveLayer<T>::begin() const {
   return elements_.begin();

--- a/lanelet2_examples/src/04_reading_and_writing/main.cpp
+++ b/lanelet2_examples/src/04_reading_and_writing/main.cpp
@@ -80,7 +80,8 @@ class FakeWriter : public lanelet::io_handlers::Writer {
  public:
   using Writer::Writer;
   void write(const std::string& /*filename*/, const lanelet::LaneletMap& /*laneletMap*/,
-             lanelet::ErrorMessages& /*errors*/, const lanelet::io::Configuration& /*params*/) const override {
+             lanelet::ErrorMessages& /*errors*/, const lanelet::io::Configuration& /*params*/, 
+             bool /*increment_versions*/) const override {
     // this writer does just nothing
   }
   static constexpr const char* extension() {

--- a/lanelet2_io/include/lanelet2_io/Io.h
+++ b/lanelet2_io/include/lanelet2_io/Io.h
@@ -111,7 +111,7 @@ std::vector<std::string> supportedParserExtensions();
  * (lat/lon) data. If no origin is specified, the written map will most likely be not correctly located and deformed.
  */
 void write(const std::string& filename, const lanelet::LaneletMap& map, const Origin& origin = Origin::defaultOrigin(),
-           ErrorMessages* errors = nullptr, const io::Configuration& params = io::Configuration());
+           ErrorMessages* errors = nullptr, const io::Configuration& params = io::Configuration(), bool increment_versions = false);
 
 /**
  * @brief writes a map to a file
@@ -125,7 +125,7 @@ void write(const std::string& filename, const lanelet::LaneletMap& map, const Or
  * @throws lanelet2::IOError if the file could not be created or writing failed.
  */
 void write(const std::string& filename, const LaneletMap& map, const Projector& projector,
-           ErrorMessages* errors = nullptr, const io::Configuration& params = io::Configuration());
+           ErrorMessages* errors = nullptr, const io::Configuration& params = io::Configuration(), bool increment_versions = false);
 
 /**
  * @brief writes a map to a file
@@ -140,8 +140,8 @@ void write(const std::string& filename, const LaneletMap& map, const Projector& 
  */
 void write(const std::string& filename, const lanelet::LaneletMap& map, const std::string& writerName,
            const Origin& origin = Origin::defaultOrigin(), ErrorMessages* errors = nullptr,
-           const io::Configuration& params = io::Configuration());
-
+           const io::Configuration& params = io::Configuration(), bool increment_versions = false);
+           
 /**
  * @brief writes a map to a file
  * @param filename file to write to (parent folders must exist!). The extension is used to deduce the format.
@@ -155,7 +155,7 @@ void write(const std::string& filename, const lanelet::LaneletMap& map, const st
  */
 void write(const std::string& filename, const LaneletMap& map, const std::string& writerName,
            const Projector& projector, ErrorMessages* errors = nullptr,
-           const io::Configuration& params = io::Configuration());
+           const io::Configuration& params = io::Configuration(), bool increment_versions = false);
 
 /**
  * @brief returns the names of the currently registered writing (writers from plugins included)

--- a/lanelet2_io/include/lanelet2_io/io_handlers/BinHandler.h
+++ b/lanelet2_io/include/lanelet2_io/io_handlers/BinHandler.h
@@ -12,7 +12,7 @@ class BinWriter : public Writer {
   using Writer::Writer;
 
   void write(const std::string& filename, const LaneletMap& laneletMap, ErrorMessages& /*errors*/,
-             const io::Configuration& /*params*/) const override;
+             const io::Configuration& /*params*/, bool /*increment_versions*/ = false) const override;
 
   static constexpr const char* extension() { return ".bin"; }
 

--- a/lanelet2_io/include/lanelet2_io/io_handlers/OsmFile.h
+++ b/lanelet2_io/include/lanelet2_io/io_handlers/OsmFile.h
@@ -27,17 +27,18 @@ struct Primitive {
   Primitive(const Primitive& rhs) = delete;
   Primitive& operator=(const Primitive& rhs) = delete;
   virtual ~Primitive() = default;
-  Primitive(Id id, Attributes attributes) : id{id}, attributes{std::move(attributes)} {}
+  Primitive(Id id, Attributes attributes, uint32_t version = 0) : id{id}, attributes{std::move(attributes)}, version{version} {}
   virtual std::string type() = 0;
 
   Id id{0};
   Attributes attributes;
+  uint32_t version{0};
 };
 
 //! Osm node object
 struct Node : public Primitive {
   Node() = default;
-  Node(Id id, Attributes attributes, GPSPoint point) : Primitive{id, std::move(attributes)}, point{point} {}
+  Node(Id id, Attributes attributes, GPSPoint point, uint32_t version = 0) : Primitive{id, std::move(attributes), version}, point{point} {}
   std::string type() override { return "node"; }
   GPSPoint point;
 };
@@ -45,8 +46,8 @@ struct Node : public Primitive {
 //! Osm way object
 struct Way : public Primitive {
   Way() = default;
-  Way(Id id, Attributes attributes, std::vector<Node*> nodes)
-      : Primitive{id, std::move(attributes)}, nodes{std::move(nodes)} {}
+  Way(Id id, Attributes attributes, std::vector<Node*> nodes, uint32_t version = 0)
+      : Primitive{id, std::move(attributes), version}, nodes{std::move(nodes)} {}
   std::string type() override { return "way"; }
   std::vector<Node*> nodes;
 };
@@ -54,8 +55,8 @@ struct Way : public Primitive {
 //! Osm relation object
 struct Relation : public Primitive {
   Relation() = default;
-  Relation(Id id, Attributes attributes, Roles roles = Roles())
-      : Primitive{id, std::move(attributes)}, members{std::move(roles)} {}
+  Relation(Id id, Attributes attributes, Roles roles = Roles(), uint32_t version = 0)
+      : Primitive{id, std::move(attributes), version}, members{std::move(roles)} {}
   std::string type() override { return "relation"; }
   Roles members;
 };

--- a/lanelet2_io/include/lanelet2_io/io_handlers/OsmHandler.h
+++ b/lanelet2_io/include/lanelet2_io/io_handlers/OsmHandler.h
@@ -18,10 +18,11 @@ class OsmWriter : public Writer {
    * "josm_format_elevation": whether to format elevation to 2 decimal places as required by JSOM, "false" by default
    */
   void write(const std::string& filename, const LaneletMap& laneletMap, ErrorMessages& errors,
-             const io::Configuration& params = io::Configuration()) const override;
-
+             const io::Configuration& params = io::Configuration(), bool increment_versions = false) const override;
+  
   std::unique_ptr<osm::File> toOsmFile(const LaneletMap& laneletMap, ErrorMessages& errors,
-                                       const io::Configuration& params = io::Configuration()) const;
+                                       const io::Configuration& params = io::Configuration(),  
+                                       bool increment_versions = false) const;
 
   static constexpr const char* extension() { return ".osm"; }
 

--- a/lanelet2_io/include/lanelet2_io/io_handlers/Writer.h
+++ b/lanelet2_io/include/lanelet2_io/io_handlers/Writer.h
@@ -26,7 +26,7 @@ class Writer : public IOHandler {
   using Ptr = std::shared_ptr<Writer>;
 
   virtual void write(const std::string& filename, const LaneletMap& laneletMap, ErrorMessages& errors,
-                     const io::Configuration& params = io::Configuration()) const = 0;
+                     const io::Configuration& params = io::Configuration(), bool increment_versions = false) const = 0;
 
   // IOHandler interface
  private:

--- a/lanelet2_io/src/BinHandler.cpp
+++ b/lanelet2_io/src/BinHandler.cpp
@@ -18,7 +18,7 @@ RegisterWriter<BinWriter> regWriter;
 
 }  // namespace
 
-void BinWriter::write(const std::string& filename, const LaneletMap& laneletMap, ErrorMessages& /*errors*/, const io::Configuration& /*params*/) const {
+void BinWriter::write(const std::string& filename, const LaneletMap& laneletMap, ErrorMessages& /*errors*/, const io::Configuration& /*params*/, bool /*increment_versions*/) const {
   std::ofstream fs(filename, std::ofstream::binary);
   if (!fs.good()) {
     throw ParseError("Failed open archive " + filename);

--- a/lanelet2_io/src/Io.cpp
+++ b/lanelet2_io/src/Io.cpp
@@ -58,24 +58,24 @@ std::vector<std::string> supportedParsers() { return io_handlers::ParserFactory:
 
 std::vector<std::string> supportedParserExtensions() { return io_handlers::ParserFactory::availableExtensions(); }
 
-void write(const std::string& filename, const LaneletMap& map, const Origin& origin, ErrorMessages* errors, const io::Configuration& params) {
-  write(filename, map, defaultProjection(origin), errors, params);
+void write(const std::string& filename, const LaneletMap& map, const Origin& origin, ErrorMessages* errors, const io::Configuration& params, bool increment_versions) {
+  write(filename, map, defaultProjection(origin), errors, params, increment_versions);
 }
 
-void write(const std::string& filename, const LaneletMap& map, const Projector& projector, ErrorMessages* errors, const io::Configuration& params) {
+void write(const std::string& filename, const LaneletMap& map, const Projector& projector, ErrorMessages* errors, const io::Configuration& params, bool increment_versions) {
   ErrorMessages err;
-  io_handlers::WriterFactory::createFromExtension(extension(filename), projector, params)->write(filename, map, err, params);
+  io_handlers::WriterFactory::createFromExtension(extension(filename), projector, params)->write(filename, map, err, params, increment_versions);
   handleErrorsOrThrow<WriteError>(err, errors);
 }
 
-void write(const std::string& filename, const LaneletMap& map, const std::string& writerName, const Origin& origin, ErrorMessages* errors, const io::Configuration& params) {
-  write(filename, map, writerName, defaultProjection(origin), errors, params);
+void write(const std::string& filename, const LaneletMap& map, const std::string& writerName, const Origin& origin, ErrorMessages* errors, const io::Configuration& params, bool increment_versions) {
+  write(filename, map, writerName, defaultProjection(origin), errors, params, increment_versions);
 }
 
 void write(const std::string& filename, const LaneletMap& map, const std::string& writerName,
-           const Projector& projector, ErrorMessages* errors, const io::Configuration& params) {
+           const Projector& projector, ErrorMessages* errors, const io::Configuration& params, bool increment_versions) {
   ErrorMessages err;
-  io_handlers::WriterFactory::create(writerName, projector, params)->write(filename, map, err, params);
+  io_handlers::WriterFactory::create(writerName, projector, params)->write(filename, map, err, params, increment_versions);
   handleErrorsOrThrow<WriteError>(err, errors);
 }
 

--- a/lanelet2_io/src/OsmHandlerLoad.cpp
+++ b/lanelet2_io/src/OsmHandlerLoad.cpp
@@ -90,7 +90,7 @@ class FromFileLoader {  // NOLINT
     for (const auto& nodeElem : nodes) {
       const auto& node = nodeElem.second;
       try {
-        points_.emplace(node.id, Point3d(node.id, projector.forward(node.point), getAttributes(node.attributes)));
+        points_.emplace(node.id, Point3d(node.id, projector.forward(node.point), getAttributes(node.attributes), node.version));
       } catch (ForwardProjectionError& e) {
         parserError(node.id, e.what());
       }
@@ -109,6 +109,7 @@ class FromFileLoader {  // NOLINT
       }
 
       const auto id = way.id;
+      const auto version = way.version;
       const auto attributes = getAttributes(way.attributes);
 
       // determine area or way
@@ -116,7 +117,7 @@ class FromFileLoader {  // NOLINT
       if (isArea != attributes.end() && isArea->second.asBool().get_value_or(false)) {
         polygons_.emplace(id, Polygon3d(id, points, attributes));
       } else {
-        lineStrings_.emplace(id, LineString3d(id, points, attributes));
+        lineStrings_.emplace(id, LineString3d(id, points, attributes, version));
       }
     }
   }
@@ -133,6 +134,7 @@ class FromFileLoader {  // NOLINT
       }
       const auto id = llElem.id;
       const auto attributes = getAttributes(llElem.attributes);
+      const auto version = llElem.version;
       auto left = getLaneletBorder(llElem, RoleNameString::Left);
       auto right = getLaneletBorder(llElem, RoleNameString::Right);
 
@@ -140,7 +142,7 @@ class FromFileLoader {  // NOLINT
       std::tie(left, right) = geometry::align(left, right);
 
       // look for optional centerline
-      Lanelet lanelet(id, left, right, attributes);
+      Lanelet lanelet(id, left, right, attributes, {}, version);
       if (findRole(llElem.members, RoleNameString::Centerline) != llElem.members.end()) {
         auto center = getLaneletBorder(llElem, RoleNameString::Centerline);
         lanelet.setCenterline(center);

--- a/lanelet2_python/python_api/core.cpp
+++ b/lanelet2_python/python_api/core.cpp
@@ -254,6 +254,8 @@ class IsPrimitive : public def_visitor<IsPrimitive<PrimT>> {
     const AttributeMap& (PrimT::*attr)() const = &PrimT::attributes;
     c.add_property("id", &PrimT::id, &PrimT::setId,
                    "Unique ID of this primitive. 0 is a special value for temporary objects.");
+    c.add_property("version", &PrimT::version, &PrimT::setVersion,
+                   "Version of this primitive. 0 is a special value for newly created objects, on write it will be set to 1.");
     c.add_property("attributes", getRefFunc(attr), setAttributeWrapper<PrimT>,
                    "The attributes of this primitive as key value types. Behaves like a dictionary.");
     c.def(self == self);  // NOLINT
@@ -400,7 +402,13 @@ auto wrapLayer(const char* layerName) {
           "Retrieve an element by its ID")
       .def("search", search, arg("boundingBox"), "Search in a search area defined by a 2D bounding box")
       .def("nearest", nearest, (arg("point"), arg("n") = 1), "Gets a list of the nearest n primitives to a given point")
-      .def("uniqueId", &LayerT::uniqueId, "Retrieve an ID that not yet used in this layer");
+      .def("uniqueId", &LayerT::uniqueId, "Retrieve an ID that not yet used in this layer")
+      .def(
+          "setVersions", &LayerT::setVersions, arg("version"),
+          "set given version to primitives")
+      .def(
+          "increment_versions", &LayerT::incrementVersions,
+          "update primitives versions");
 }
 
 template <typename PrimT>
@@ -1160,6 +1168,8 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
       no_init)
       .def(IsConstPrimitive<RegulatoryElement>())
       .add_property("id", &RegulatoryElement::id, &RegulatoryElement::setId)
+      .add_property("version", &RegulatoryElement::version, &RegulatoryElement::setVersion,
+                   "Version of this primitive. 0 is a special value for newly created objects, on write it will be set to 1.")
       .add_property("parameters", static_cast<GetParamSig>(&RegulatoryElement::getParameters),
                     "The parameters (ie traffic signs, lanelets) that affect "
                     "this RegulatoryElement")

--- a/lanelet2_python/python_api/io.cpp
+++ b/lanelet2_python/python_api/io.cpp
@@ -42,17 +42,17 @@ py::tuple loadWithErrorWrapper(const std::string& filename, const Projector& pro
   return py::make_tuple(map, errs);
 }
 
-void writeWrapper(const std::string& filename, const LaneletMap& map, const Origin& origin, const Optional<io::Configuration>& params) {
-  write(filename, map, origin, nullptr, params.get_value_or(io::Configuration()));
+void writeWrapper(const std::string& filename, const LaneletMap& map, const Origin& origin, bool increment_versions, const Optional<io::Configuration>& params) {
+  write(filename, map, origin, nullptr, params.get_value_or(io::Configuration()), increment_versions);
 }
 
-void writeProjectorWrapper(const std::string& filename, const LaneletMap& map, const Projector& projector, const Optional<io::Configuration>& params) {
-  write(filename, map, projector, nullptr, params.get_value_or(io::Configuration()));
+void writeProjectorWrapper(const std::string& filename, const LaneletMap& map, const Projector& projector, bool increment_versions, const Optional<io::Configuration>& params) {
+  write(filename, map, projector, nullptr, params.get_value_or(io::Configuration()), increment_versions);
 }
 
-ErrorMessages writeWithErrorWrapper(const std::string& filename, const LaneletMap& map, const Projector& projector, const Optional<io::Configuration>& params) {
+ErrorMessages writeWithErrorWrapper(const std::string& filename, const LaneletMap& map, const Projector& projector, bool increment_versions, const Optional<io::Configuration>& params) {
   ErrorMessages errs;
-  write(filename, map, projector, &errs, params.get_value_or(io::Configuration()));
+  write(filename, map, projector, &errs, params.get_value_or(io::Configuration()), increment_versions);
   return errs;
 }
 
@@ -79,13 +79,15 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
       "Loads a map robustly. Parser errors are returned as second member of "
       "the tuple. If there are errors, the map will be incomplete somewhere.");
 
-  py::def("write", writeProjectorWrapper, (py::arg("filename"), py::arg("map"), py::arg("projector"), py::arg("params") = Optional<io::Configuration>{}),
+  py::def("write", writeProjectorWrapper, (py::arg("filename"), py::arg("map"), py::arg("projector"), py::arg("increment_versions") = false, py::arg("params") = Optional<io::Configuration>{}),
       "Writes the map to a file. The extension determines which format will "
       "be used (usually .osm)");
-  py::def("write", writeWrapper, (py::arg("filename"), py::arg("map"), py::arg("origin"), py::arg("params") = Optional<io::Configuration>{}),
+
+  py::def("write", writeWrapper, (py::arg("filename"), py::arg("map"), py::arg("origin"), py::arg("increment_versions") = false, py::arg("params") = Optional<io::Configuration>{}),
       "Writes the map to a file. The extension determines which format will "
       "be used (usually .osm)");
-  py::def("writeRobust", writeWithErrorWrapper, (py::arg("filename"), py::arg("map"), py::arg("projector"), py::arg("params") = Optional<io::Configuration>{}),
+
+  py::def("writeRobust", writeWithErrorWrapper, (py::arg("filename"), py::arg("map"), py::arg("projector"), py::arg("increment_versions") = false, py::arg("params") = Optional<io::Configuration>{}),
       "Writes a map robustly and returns writer errors. If there are errors, "
       "the map will be incomplete somewhere.");
 }


### PR DESCRIPTION
Hello, I'm currently working on algorythm to merge changes, made on base of one map, but done by different people. For this reason, I need to determine the last version of changed primitives,luckily, the osm format has "version" field, but in Lanelet2 library the version field was hardcodly set to "1".  So, here some updates I've done:
* Optional parameter "version" in primitives' constructors. Default value 0.   
* Read primitives' versions from file.
* Write primitives' versions into file.
* Possibility to increment version for single primitive.
* Possibility to increment versions for all primitives in layer.
* Possibility to increment all primitives' versions on writing to file by bool parameter (minimum version will be written "1").
* Possibility to set version for single primitive.
* Possibility to set version for all primitives in layer.
* Updated Python API with versioning functionality.
---------