### PR TITLE
Added missing to_python converter for ConstWeakLanelet

### DIFF
--- a/lanelet2_python/python_api/core.cpp
+++ b/lanelet2_python/python_api/core.cpp
@@ -152,6 +152,12 @@ struct ConstLaneletOrAreaToObject {
   }
 };
 
+struct ConstWeakLaneletToObject {
+  static PyObject* convert(const lanelet::ConstWeakLanelet& v) {
+    return incref(object(v.lock()).ptr());
+  }
+};
+
 template <class T>
 struct MapItem {
   using K = typename T::key_type;
@@ -658,6 +664,8 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
   to_python_converter<LineStringOrPolygon3d, LineStringOrPolygonToObject>();
   to_python_converter<ConstLineStringOrPolygon3d, ConstLineStringOrPolygonToObject>();
   to_python_converter<ConstLaneletOrArea, ConstLaneletOrAreaToObject>();
+  to_python_converter<ConstWeakLanelet, ConstWeakLaneletToObject>();
+  
   implicitly_convertible<LineString3d, LineStringOrPolygon3d>();
   implicitly_convertible<Polygon3d, LineStringOrPolygon3d>();
   implicitly_convertible<ConstLineString3d, ConstLineStringOrPolygon3d>();


### PR DESCRIPTION
First of all: thanks for the great work!
I was playing around with the Python API and loading `RightOfWay` Objects from the [sample map](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/blob/master/lanelet2_maps/res/mapping_example.osm).
However, access to the `'right_of_way'` and `'yield'` keys of the `parameters` attribute of the `RightOfWay` Object was not possible due to a missing to_python converter for `ConstWeakLanelet`.
I'm not sure whether this was intentional or not.

However - I added it, direct access through the `parameters` attribute now works and shows the same results as calling the `rightOfWayLanelets() ` method. Same goes for the `'yield'` key and `yieldLanelets()` method.

This is related to #233 