### PR TITLE
Fix buildfarm by find_package GeographicLib

### DIFF
--- a/lanelet2_projection/CMakeLists.txt
+++ b/lanelet2_projection/CMakeLists.txt
@@ -10,6 +10,10 @@ find_package(mrt_cmake_modules REQUIRED)
 include(UseMrtStdCompilerFlags)
 include(GatherDeps)
 
+# Geographiclib installs FindGeographicLib.cmake to this non-standard location
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "/usr/share/cmake/geographiclib/")
+find_package(GeographicLib REQUIRED)
+
 # You can add a custom.cmake in order to add special handling for this package. E.g. you can do:
 # list(REMOVE_ITEM DEPENDEND_PACKAGES <package name 1> <package name 2> ...)
 # To remove libs which cannot be found automatically. You can also "find_package" other, custom dependencies there.


### PR DESCRIPTION
Buildfarm fails: https://build.ros2.org/job/Rbin_unv8_uNv8__lanelet2_projection__ubuntu_noble_arm64__binary/99/console

Because of this missing find-package.

Custom location syntax is the same as other succeeding packages.