### PR TITLE
downgrade patchelf version to fix failing CD for 20.04

### DIFF
--- a/.github/conan_dockerfile/Dockerfile
+++ b/.github/conan_dockerfile/Dockerfile
@@ -18,8 +18,8 @@ RUN pyenv update \
 RUN pip install "conan~=2.8.0" catkin_pkg "numpy<2.0" wheel auditwheel cmake
 
 # install patchelf
-RUN wget https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-x86_64.tar.gz \
-  && tar -xzf patchelf-0.18.0-x86_64.tar.gz \
+RUN wget https://github.com/NixOS/patchelf/releases/download/0.17.2/patchelf-0.17.2-x86_64.tar.gz \
+  && tar -xzf patchelf-0.17.2-x86_64.tar.gz \
   && sudo -E ln -s $HOME/bin/patchelf /bin/patchelf \
   && patchelf --version
 


### PR DESCRIPTION
The CD pipeline fails for Ubuntu 20.04 after the migration to conan 2 because of an issue in patchelf 0.18.0 ([ELF load command address/offset not properly aligned](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/actions/runs/11326296102) ): https://github.com/NixOS/patchelf/issues/492 

This fixes this issue by downgrading patchelf again: https://github.com/immel-f/Lanelet2/actions/runs/11326786466