### PR TITLE
Pin deploy pages ubuntu version to fix failing CD

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -127,7 +127,7 @@ jobs:
           password: ${{ secrets.PYPI_API_TOKEN }}
 
   deploy-pages:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.ref == 'refs/heads/master'
     concurrency: deploy-${{ github.ref }}
     steps:


### PR DESCRIPTION
Now the deploy pages part of the CD (which was not run during my test run in my fork) [fails](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/actions/runs/11345517462/job/31553162368) because the previously used ubuntu-latest image [changed to 24.04](https://github.com/actions/runner-images/issues/10636) which does not support Python 3.7. This pins the version to the previous 22.04 to fix this issue