### PR TITLE
Python repr fix for RecursionError caused by circular references in lanelets with regulatory elements

### DIFF
--- a/lanelet2_core/include/lanelet2_core/primitives/RegulatoryElement.h
+++ b/lanelet2_core/include/lanelet2_core/primitives/RegulatoryElement.h
@@ -457,6 +457,8 @@ inline boost::optional<ConstArea> RegulatoryElement::find<ConstArea>(Id id) cons
 }
 
 std::ostream& operator<<(std::ostream& stream, const RegulatoryElement& obj);
+std::ostream& operator<<(std::ostream& stream, const RuleParameterMap& map);
+std::ostream& operator<<(std::ostream& stream, const ConstRuleParameterMap& map);
 
 template <>
 inline std::vector<ConstLanelet> RegulatoryElement::getParameters(const std::string& role) const {

--- a/lanelet2_core/src/RegulatoryElement.cpp
+++ b/lanelet2_core/src/RegulatoryElement.cpp
@@ -176,15 +176,31 @@ std::ostream& operator<<(std::ostream& stream, const RegulatoryElement& obj) {
   stream << "[id: " << obj.id();
   if (!obj.empty()) {
     stream << ", parameters: ";
-    for (auto& param : obj.getParameters()) {
+    stream << obj.getParameters();
+  }
+  return stream << ']';
+}
+
+std::ostream& operator<<(std::ostream& stream, const RuleParameterMap& map) {
+  for (const auto& param : map) {
       stream << '{' << param.first << ':' << ' ';
       for (auto& rule : param.second) {
         stream << GetIdVisitor::id(rule) << ' ';
       }
       stream << '}';
     }
-  }
-  return stream << ']';
+  return stream;
+}
+
+std::ostream& operator<<(std::ostream& stream, const ConstRuleParameterMap& map) {
+  for (const auto& param : map) {
+      stream << '{' << param.first << ':' << ' ';
+      for (auto& rule : param.second) {
+        stream << GetIdVisitor::id(rule) << ' ';
+      }
+      stream << '}';
+    }
+  return stream;
 }
 
 template <>

--- a/lanelet2_python/python_api/core.cpp
+++ b/lanelet2_python/python_api/core.cpp
@@ -1036,6 +1036,8 @@ BOOST_PYTHON_MODULE(PYTHON_API_MODULE_NAME) {  // NOLINT
       .def("__len__", &LaneletSequence::size, "Number of lanelets in this sequence")
       .def("inverted", &LaneletSequence::inverted, "True if this lanelet sequence is inverted")
       .def(
+          "__str__", +[](const LaneletSequence& s) { return makeRepr("LaneletSequence", s.lanelets()); })
+      .def(
           "__repr__", +[](const LaneletSequence& s) { return makeRepr("LaneletSequence", repr(object(s.lanelets()))); })
       .def("__getitem__", wrappers::getItem<LaneletSequence>, return_internal_reference<>(),
            "Returns a lanelet in the sequence");

--- a/lanelet2_python/test/test_lanelet2.py
+++ b/lanelet2_python/test/test_lanelet2.py
@@ -1,6 +1,6 @@
 import unittest
 import lanelet2  # if we fail here, there is something wrong with registration
-from lanelet2.core import AttributeMap, getId, BasicPoint2d, Point3d, LineString3d, Lanelet, RegulatoryElement, TrafficLight, LaneletMap, createMapFromLanelets
+from lanelet2.core import AttributeMap, getId, BasicPoint2d, Point3d, LineString3d, Lanelet, RegulatoryElement, TrafficLight, LaneletMap, createMapFromLanelets, RightOfWay
 from lanelet2.geometry import distance, intersects2d, boundingBox2d, to2D, intersection
 
 
@@ -24,10 +24,51 @@ def getRegelem():
     return TrafficLight(getId(), AttributeMap(), [getLineString()], getLineString())
 
 
+def getStopLine():
+    stopLine = getLineString()
+    stopLine.attributes["type"] = "stop_line"
+    return stopLine
+
+
+# need to pass lanelets as arguments, otherwise they are lost, resulting in
+# RuntimeError: Nullptr passed to constructor!
+def getRightOfWay(row_lanelets, yield_lanelets):
+    return RightOfWay(getId(), getAttributes(), row_lanelets, yield_lanelets, getStopLine())
+
+
 def getLaneletMap():
     lanelet = getLanelet()
     lanelet.addRegulatoryElement(getRegelem())
     return createMapFromLanelets([lanelet])
+
+
+def getLaneletMapWithRightOfWay():
+    yieldLanelet = getLanelet()
+    rightOfWayLanelet = getLanelet()
+    rightOfWay = getRightOfWay([rightOfWayLanelet], [yieldLanelet])
+    rightOfWayLanelet.id = 2000
+    rightOfWayLanelet.leftBound.id = 2001
+    rightOfWayLanelet.leftBound[0].id = 3000
+    rightOfWayLanelet.leftBound[1].id = 3001
+    rightOfWayLanelet.rightBound.id = 2002
+    rightOfWayLanelet.rightBound[0].id = 3003
+    rightOfWayLanelet.rightBound[1].id = 3004
+    yieldLanelet.id = 2003
+    yieldLanelet.leftBound.id = 2004
+    yieldLanelet.leftBound[0].id = 3010
+    yieldLanelet.leftBound[1].id = 3011
+    yieldLanelet.rightBound.id = 2005
+    yieldLanelet.rightBound[0].id = 3013
+    yieldLanelet.rightBound[1].id = 3014
+    rightOfWay.id = 2006
+    rightOfWay.stopLine.id = 2007
+    rightOfWay.stopLine[0].id = 3020
+    rightOfWay.stopLine[1].id = 3021
+    rightOfWayLanelet.addRegulatoryElement(rightOfWay)
+    yieldLanelet.addRegulatoryElement(rightOfWay)
+    llmap = createMapFromLanelets([rightOfWayLanelet, yieldLanelet])
+    llmap.add(rightOfWay)
+    return llmap
 
 
 def checkPrimitiveId(testClass, primitive):
@@ -43,6 +84,46 @@ def checkPrimitiveAttributes(testClass, primitive):
     testClass.assertEqual(primitive.attributes["newkey"], "newvalue")
     del primitive.attributes["newkey"]
     testClass.assertFalse("newkey" in primitive.attributes)
+
+
+class LaneletReprTestCase(unittest.TestCase):
+    def test_lanelet_row_repr(self):
+        map = getLaneletMapWithRightOfWay()
+        self.assertEqual(len(map.regulatoryElementLayer), 1)
+        rightOfWay = map.regulatoryElementLayer[2006]
+        rightOfWayLanelet = map.laneletLayer[2000]
+
+        rightOfWayParamsRepr = \
+            "RuleParameterMap({" + \
+                "'ref_line': [ConstLineString3d(2007, [" + \
+                        "ConstPoint3d(3020, 0, 0, 0, AttributeMap({'key': 'value'})), " + \
+                        "ConstPoint3d(3021, 0, 0, 0, AttributeMap({'key': 'value'}))" + \
+                    "], AttributeMap({'key': 'value', 'type': 'stop_line'}))], " + \
+                "'right_of_way': [[id: 2000, left id: 2001, right id: 2002]], " + \
+                "'yield': [[id: 2003, left id: 2004, right id: 2005]]" + \
+            "})"
+        self.assertEqual(repr(rightOfWay.parameters), rightOfWayParamsRepr)
+        self.assertEqual(str(rightOfWay.parameters), "{ref_line: 2007 }{right_of_way: 2000 }{yield: 2003 }")
+
+        rightOfWayRepr = "RightOfWay(2006, " + rightOfWayParamsRepr + \
+            ", AttributeMap({'key': 'value', 'subtype': 'right_of_way', 'type': 'regulatory_element'}))"
+        self.assertEqual(repr(rightOfWay), rightOfWayRepr)
+        self.assertEqual(str(rightOfWay), "[id: 2006, parameters: {ref_line: 2007 }{right_of_way: 2000 }{yield: 2003 }]")
+
+        rightOfWayLaneletRepr = \
+            "Lanelet(2000, " + \
+                "LineString3d(2001, [" + \
+                    "Point3d(3000, 0, 0, 0, AttributeMap({'key': 'value'})), " + \
+                    "Point3d(3001, 0, 0, 0, AttributeMap({'key': 'value'}))" + \
+                "], AttributeMap({'key': 'value'})), " + \
+                "LineString3d(2002, [" + \
+                    "Point3d(3003, 0, 0, 0, AttributeMap({'key': 'value'})), " + \
+                    "Point3d(3004, 0, 0, 0, AttributeMap({'key': 'value'}))" + \
+                "], AttributeMap({'key': 'value'})), " + \
+                "AttributeMap({'key': 'value'}), " + \
+                "[" + rightOfWayRepr + "])"
+        self.assertEqual(repr(rightOfWayLanelet), rightOfWayLaneletRepr)
+        self.assertEqual(str(rightOfWayLanelet), "[id: 2000, left id: 2001, right id: 2002]")
 
 
 class LaneletApiTestCase(unittest.TestCase):
@@ -65,6 +146,19 @@ class LaneletApiTestCase(unittest.TestCase):
         self.assertEqual(len(llt.trafficLights()), 1)
         self.assertEqual(len(llt.trafficSigns()), 0)
         self.assertEqual(len(llt.regulatoryElements), 1)
+
+    def test_lanelet_row(self):
+        rightOfWayLanelet = getLanelet()
+        yieldLanelet = getLanelet()
+        rightOfWay = getRightOfWay([rightOfWayLanelet], [yieldLanelet])
+        rightOfWayLanelet.addRegulatoryElement(rightOfWay)
+        yieldLanelet.addRegulatoryElement(rightOfWay)
+        self.assertEqual(len(rightOfWayLanelet.rightOfWay()), 1)
+        self.assertEqual(len(rightOfWayLanelet.regulatoryElements), 1)
+        self.assertEqual(len(yieldLanelet.rightOfWay()), 1)
+        self.assertEqual(len(yieldLanelet.regulatoryElements), 1)
+        self.assertEqual(len(rightOfWay.rightOfWayLanelets()), 1)
+        self.assertEqual(len(rightOfWay.yieldLanelets()), 1)
 
 
 class LaneletMapApiTestCase(unittest.TestCase):


### PR DESCRIPTION
This MR contains some small fixes related to calling `repr` and `str` on python lanelet objects. 

- when calling `repr` of a lanelet that contains regulatory elements with a reference back to the lanelet, you currently get 
```
# Traceback (most recent call last):
#   File "<stdin>", line 1, in <module>
# RecursionError: maximum recursion depth exceeded while calling a Python object
```
This is fixed by printing only `str` for `Lanelet`s in `RuleParameter` instead of `repr`, which breaks the loop
- `str` now returns a concise information whereas `repr` contains the full object description in more cases.

For some reason [this](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/blob/master/lanelet2_core/include/lanelet2_core/utility/HybridMap.h#L235) is not working as expected for `RuleParameterMap`, as can be seen by trying to run `std::cout << trafficLightRegelem->getParameters();` [here](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/blob/master/lanelet2_examples/src/02_regulatory_elements/main.cpp#L60). Hence, I had to add methods for the `repr` of the `RuleParameterMap`

Example code:
```python
import os
import lanelet2
from lanelet2.projection import UtmProjector

map_file = os.path.join("src", "lanelet2", "lanelet2_maps", "res", "mapping_example.osm")
projector = UtmProjector(lanelet2.io.Origin(49, 8.4))
loadedMap = lanelet2.io.load(map_file, projector)

ll = loadedMap.laneletLayer[45014]
print(str(ll))
print(repr(ll))

reg_els = ll.regulatoryElements
print(str(reg_els))
print(repr(reg_els))

# Right of way
reg_el = reg_els[0]
print(str(reg_el))
print(repr(reg_el))
print(str(reg_el.parameters))
print(repr(reg_el.parameters))
```