### PR TITLE
CI Fixes for Breaking Github Changes

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -70,7 +70,7 @@ jobs:
             sudo cp -r $HOME/dist/* /dist
 
       - name: Store wheel
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
@@ -85,7 +85,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Restore wheel
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
@@ -110,7 +110,7 @@ jobs:
     needs: [build, test]
     steps:
       - name: Restore wheel
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -72,7 +72,7 @@ jobs:
       - name: Store wheel
         uses: actions/upload-artifact@v4
         with:
-          name: dist
+          name: dist-${{ matrix.python-version }}
           path: dist/
 
   test:
@@ -87,7 +87,8 @@ jobs:
       - name: Restore wheel
         uses: actions/download-artifact@v4
         with:
-          name: dist
+          pattern: dist-*
+          merge-multiple: true
           path: dist/
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -112,7 +113,8 @@ jobs:
       - name: Restore wheel
         uses: actions/download-artifact@v4
         with:
-          name: dist
+          pattern: dist-*
+          merge-multiple: true
           path: dist/
 
       - name: Release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,9 @@ on:
   # Run tests for any PRs.
   pull_request:
 
+permissions:
+  issues: write
+
 jobs:
   formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   issues: write
+  contents: write
 
 jobs:
   formatting:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,7 +170,7 @@ jobs:
           docker rm -f lanelet2_test_${{ matrix.rosdistro }}_lcov;
 
       - name: Report code coverage
-        uses: immel-f/github-actions-report-lcov@v0.1.12
+        uses: immel-f/github-actions-report-lcov@v0.1.13
         if: ${{ matrix.rosdistro == 'noetic' }}
         with:
           coverage-files: ./lcov/full_coverage.lcov

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,7 +174,7 @@ jobs:
         if: ${{ matrix.rosdistro == 'noetic' }}
         with:
           coverage-files: ./lcov/full_coverage.lcov
-          artifact-name: code-coverage-report-${{ matrix.rosdistro }}
+          artifact-name: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   full_conan_installation:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,7 +174,7 @@ jobs:
         if: ${{ matrix.rosdistro == 'noetic' }}
         with:
           coverage-files: ./lcov/full_coverage.lcov
-          artifact-name: code-coverage-report
+          artifact-name: code-coverage-report-${{ matrix.rosdistro }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   full_conan_installation:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,7 +170,7 @@ jobs:
           docker rm -f lanelet2_test_${{ matrix.rosdistro }}_lcov;
 
       - name: Report code coverage
-        uses: immel-f/github-actions-report-lcov@v0.1.11
+        uses: immel-f/github-actions-report-lcov@v0.1.12
         if: ${{ matrix.rosdistro == 'noetic' }}
         with:
           coverage-files: ./lcov/full_coverage.lcov


### PR DESCRIPTION
Github again deprecated some CI actions, this caused breaking changes. They are fixed in this PR