### PR TITLE
add driving direction (one_way) info to debug routing graph osm output

### DIFF
--- a/lanelet2_python/scripts/create_debug_routing_graph.py
+++ b/lanelet2_python/scripts/create_debug_routing_graph.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import lanelet2
 import sys
@@ -23,6 +23,8 @@ if __name__ == "__main__":
                  "pedestrian": lanelet2.traffic_rules.Participants.Pedestrian,
                  "train": lanelet2.traffic_rules.Participants.Train}
     proj = lanelet2.projection.UtmProjector(lanelet2.io.Origin(args.lat, args.lon))
+    laneletmap = lanelet2.io.load(args.filename, proj)
+
     routing_cost = lanelet2.routing.RoutingCostDistance(0.)  # zero cost for lane changes
     traffic_rules = lanelet2.traffic_rules.create(lanelet2.traffic_rules.Locations.Germany,
                                                   rules_map[args.participant])


### PR DESCRIPTION
adds info if lanelet is oneway, since successor relationship is only giving the direction info for one_way lanelets

see:
![image](https://github.com/user-attachments/assets/55263940-fbf2-4a9f-bfb0-195933ebe3e8)

this allows to search/filter for the tag in JOSM, quickly checking for one_way=yes/no lanelets:

![image](https://github.com/user-attachments/assets/97912ab1-a123-4359-a050-c73256c3230d)
