### PR TITLE
Increase minimum CMake version and remove Ubuntu 20.04 pip tests to fix CI pipeline

### DIFF
--- a/.github/conan_dockerfile/Dockerfile
+++ b/.github/conan_dockerfile/Dockerfile
@@ -3,6 +3,7 @@ ARG FROM=conanio/gcc10:latest
 FROM ${FROM} AS lanelet2_conan_deps
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV CMAKE_POLICY_VERSION_MINIMUM 3.5
 
 # install requirements for python installation
 RUN sudo -E apt-get update \

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -81,7 +81,7 @@ jobs:
       matrix:
         # test only on currently supported version
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: ["ubuntu-20.04", "ubuntu-22.04", "ubuntu-24.04"]
+        os: ["ubuntu-22.04", "ubuntu-24.04"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Restore wheel

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,7 +15,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/mrt_cmake_modules-extras.cmake)
 """
 
 cmake_lists = """
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5.1)
 project(lanelet2)
 if(POLICY CMP0079)
   cmake_policy(SET CMP0079 NEW) # allows to do target_link_libraries on targets from subdirs

--- a/lanelet2/CMakeLists.txt
+++ b/lanelet2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5.1)
 project(lanelet2)
 if($ENV{ROS_VERSION} EQUAL 1)
   find_package(catkin REQUIRED)


### PR DESCRIPTION
The CI pipeline broke again because I think some manylinux conan dependencies use a minimum CMake version that is not supported anymore. I increased the minimum CMake version required and also made it consistent across all sub-packages of the repo. Additionally, the Ubuntu 20.04 pip tests had to be removed because of the dropped support of Ubuntu 20.04 from Github actions.