### PR TITLE
Add primitive removal feature on LaneletMap

### DIFF
--- a/lanelet2_core/include/lanelet2_core/LaneletMap.h
+++ b/lanelet2_core/include/lanelet2_core/LaneletMap.h
@@ -435,6 +435,70 @@ class LaneletMap : public LaneletMapLayers {
    * sure that the id has not already been for a different element.
    */
   void add(Point3d point);
+
+  /**
+   * @brief remove the regulatory element from the map, as well as
+   * its ownership in the lanelet and area.
+   */
+  void remove(const RegulatoryElementConstPtr& regElem);
+
+  /**
+   * @brief remove the regulatory element from the map if unused.
+   * @return true if the element was removed, false otherwise
+   *
+   * An regulatory element is unused when own by no lanelets nor areas
+   */
+  bool removeIfUnused(const RegulatoryElementConstPtr& regElem);
+
+  /**
+   * @brief remove the lanelet from the map if unused.
+   * @return true if the element was removed, false otherwise
+   *
+   * A lanelet is always unused so removal cannot fail
+   * Note: the lanelet may still be referenced by a regulatory element as parameters
+   * See RegulatoryElement.remove<ConstLanelet>(Id) to remove the references
+   */
+  bool removeIfUnused(const ConstLanelet& lanelet);
+
+  /**
+   * @brief remove the area from the map if unused.
+   * @return true if the element was removed, false otherwise
+   *
+   * An area is always unused so removal cannot fail
+   * Note: the area may still be referenced by a regulatory element as parameters.
+   * See RegulatoryElement.remove<ConstArea>(Id) to remove the references
+   */
+  bool removeIfUnused(const ConstArea& area);
+
+  /**
+   * @brief remove the polygon from the map if unused.
+   * @return true if the element was removed, false otherwise
+   *
+   * A polygon is always unused so removal cannot fail
+   * Note: the polygon may still be referenced by a regulatory element as parameters
+   * See RegulatoryElement.remove<ConstPolygon3d>(Id) to remove the references
+   */
+  bool removeIfUnused(const ConstPolygon3d& polygon);
+
+  /**
+   * @brief remove the lineString from the map if unused.
+   * @return true if the element was removed, false otherwise
+   *
+   * A lineString is unused when not owned by any lanelet nor area (inverted included)
+   * Note: the lineString may still be referenced by a regulatory element as parameters
+   * See RegulatoryElement.remove<ConstLineString3d>(Id) to remove the references
+   */
+  bool removeIfUnused(const ConstLineString3d& lineString);
+
+  /**
+   * @brief remove the point from the map if unused.
+   * @return true if the element was removed, false otherwise
+   *
+   * A point is unused when not owned by any lineString nor polygon
+   * Note: the lineString may still be referenced by a regulatory element as parameters
+   * See RegulatoryElement.remove<ConstPoint3d>(Id) to remove the references
+   */
+  bool removeIfUnused(const ConstPoint3d& point);
 };
 
 /**

--- a/lanelet2_core/include/lanelet2_core/primitives/RegulatoryElement.h
+++ b/lanelet2_core/include/lanelet2_core/primitives/RegulatoryElement.h
@@ -238,6 +238,10 @@ class RegulatoryElement  // NOLINT
   //! applies a visitor to every parameter in the regulatory element
   void applyVisitor(RuleParameterVisitor& visitor) const;
 
+  //! Remove the referencement of this primitive.
+  template <typename T>
+  void remove(Id id);
+
  protected:
   const_iterator begin() const { return constData()->parameters.begin(); }
   const_iterator end() const { return constData()->parameters.end(); }
@@ -416,6 +420,16 @@ Optional<T> RegulatoryElement::find(Id id) const {
     }
   }
   return {};
+}
+
+template <typename T>
+void RegulatoryElement::remove(Id id) {
+  for (auto& params : parameters()) {
+    auto& primitiveList = params.second;
+    primitiveList.erase(std::remove_if(primitiveList.begin(), primitiveList.end(),
+                                       [id](const auto& param) { return utils::getId(param) == id; }),
+                        primitiveList.end());
+  }
 }
 
 template <>

--- a/lanelet2_core/src/LaneletMap.cpp
+++ b/lanelet2_core/src/LaneletMap.cpp
@@ -214,6 +214,18 @@ LaneletMapUPtr createMapFromConst(const ConstLaneletsT& fromLanelets, const Cons
       fromAreas, [](const ConstArea& ar) { return Area(std::const_pointer_cast<AreaData>(ar.constData())); });
   return utils::createMap(lanelets, areas);
 }
+
+const auto remove_from_multimap = [](auto& lookup, const auto& prim, const auto& elem) {
+  auto range = lookup.equal_range(elem);
+  for (auto it = range.first; it != range.second;) {
+    if (it->second == prim) {
+      // Erase the entry, returns an iterator to the next element
+      it = lookup.erase(it);
+    } else {
+      ++it;
+    }
+  }
+};
 }  // namespace
 }  // namespace lanelet
 
@@ -225,6 +237,11 @@ struct UsageLookup {
       ownedLookup.insert(std::make_pair(elem, prim));
     }
   }
+  void remove(const T& prim) {
+    for (const auto& elem : prim) {
+      remove_from_multimap(ownedLookup, prim, elem);
+    }
+  }
   std::unordered_multimap<traits::ConstPrimitiveType<traits::OwnedT<T>>, T> ownedLookup;
 };
 
@@ -234,6 +251,13 @@ struct UsageLookup<RegulatoryElementPtr> {
     for (const auto& param : prim->getParameters()) {
       for (const auto& rule : param.second) {
         ownedLookup.insert(std::make_pair(rule, prim));
+      }
+    }
+  }
+  void remove(const RegulatoryElementPtr& prim) {
+    for (const auto& param : prim->getParameters()) {
+      for (const auto& rule : param.second) {
+        remove_from_multimap(ownedLookup, prim, rule);
       }
     }
   }
@@ -253,6 +277,19 @@ struct UsageLookup<Area> {
       regElemLookup.insert(std::make_pair(elem, area));
     }
   }
+  void remove(Area area) {
+    const auto remove_element = [this, area](auto elem) { remove_from_multimap(ownedLookup, area, elem); };
+
+    utils::forEach(area.outerBound(), remove_element);
+
+    for (const auto& innerBound : area.innerBounds()) {
+      utils::forEach(innerBound, remove_element);
+    }
+
+    for (const auto& elem : area.regulatoryElements()) {
+      remove_from_multimap(regElemLookup, area, elem);
+    }
+  }
   std::unordered_multimap<ConstLineString3d, Area> ownedLookup;
   std::unordered_multimap<RegulatoryElementConstPtr, Area> regElemLookup;
 };
@@ -265,6 +302,13 @@ struct UsageLookup<Lanelet> {
       regElemLookup.insert(std::make_pair(elem, ll));
     }
   }
+  void remove(Lanelet ll) {
+    remove_from_multimap(ownedLookup, ll, ll.leftBound());
+    remove_from_multimap(ownedLookup, ll, ll.rightBound());
+    for (const auto& elem : ll.regulatoryElements()) {
+      remove_from_multimap(regElemLookup, ll, elem);
+    }
+  }
   std::unordered_multimap<ConstLineString3d, Lanelet> ownedLookup;
   std::unordered_multimap<RegulatoryElementConstPtr, Lanelet> regElemLookup;
 };
@@ -272,6 +316,7 @@ struct UsageLookup<Lanelet> {
 template <>
 struct UsageLookup<Point3d> {
   void add(const Point3d& /*unused*/) {}
+  void remove(const Point3d& /*unused*/) {}
 };
 
 template <typename T>

--- a/lanelet2_core/src/LaneletMap.cpp
+++ b/lanelet2_core/src/LaneletMap.cpp
@@ -462,6 +462,53 @@ void PrimitiveLayer<RegulatoryElementPtr>::add(const PrimitiveLayer<RegulatoryEl
 }
 
 template <typename T>
+void PrimitiveLayer<T>::remove(Id element) {
+  if (const auto prim_it = this->find(element); prim_it != this->end()) {
+    tree_->erase(*prim_it);
+    for (const auto& elem : *prim_it) {
+      remove_from_multimap(tree_->usage.ownedLookup, *prim_it, elem);
+    }
+    this->elements_.erase(element);
+  }
+}
+
+template <>
+void PrimitiveLayer<Area>::remove(Id element) {
+  if (const auto prim_it = this->find(element); prim_it != this->end()) {
+    tree_->erase(*prim_it);
+    tree_->usage.remove(*prim_it);
+    this->elements_.erase(element);
+  }
+}
+
+template <>
+void PrimitiveLayer<Lanelet>::remove(Id element) {
+  if (const auto prim_it = this->find(element); prim_it != this->end()) {
+    tree_->erase(*prim_it);
+    tree_->usage.remove(*prim_it);
+    this->elements_.erase(element);
+  }
+}
+
+template <>
+void PrimitiveLayer<Point3d>::remove(Id element) {
+  if (const auto prim_it = this->find(element); prim_it != this->end()) {
+    tree_->erase(*prim_it);
+    tree_->usage.remove(*prim_it);
+    this->elements_.erase(element);
+  }
+}
+
+template <>
+void PrimitiveLayer<RegulatoryElementPtr>::remove(Id element) {
+  if (const auto prim_it = this->find(element); prim_it != this->end()) {
+    tree_->erase(*prim_it);
+    tree_->usage.remove(*prim_it);
+    this->elements_.erase(element);
+  }
+}
+
+template <typename T>
 std::vector<typename PrimitiveLayer<T>::ConstPrimitiveT> PrimitiveLayer<T>::findUsages(
     const traits::ConstPrimitiveType<traits::OwnedT<PrimitiveLayer<T>::PrimitiveT>>& primitive) const {
   return forEachMatchInMultiMap<traits::ConstPrimitiveType<typename PrimitiveLayer<T>::PrimitiveT>>(

--- a/lanelet2_core/test/test_regulatory_element.cpp
+++ b/lanelet2_core/test/test_regulatory_element.cpp
@@ -78,6 +78,18 @@ TEST_F(RegulatoryElementTest, findWorks) {  // NOLINT
   EXPECT_FALSE(!!regelem->find<ConstPoint3d>(ll1.id()));
 }
 
+TEST_F(RegulatoryElementTest, removeWorks) {  // NOLINT
+  auto regelem = getGenericRegelem();
+  EXPECT_FALSE(regelem->empty());
+  EXPECT_TRUE(utils::contains(regelem->roles(), RoleNameString::Cancels));
+  auto cancelLines = regelem->getParameters<ConstLineString3d>(RoleNameString::Cancels);
+  EXPECT_TRUE(cancelLines.size() == 1);
+  EXPECT_TRUE(cancelLines[0] == ls1);
+  regelem->remove<ConstLineString3d>(ls1.id());
+  EXPECT_TRUE(regelem->getParameters<ConstLineString3d>(RoleNameString::Cancels).empty());
+  EXPECT_FALSE(regelem->find<ConstLineString3d>(ls1.id()));
+}
+
 TEST_F(RegulatoryElementTest, boundingBox2dWorks) {  // NOLINT
   auto regelem = getGenericRegelem();
   auto bbox = geometry::boundingBox2d(regelem);


### PR DESCRIPTION
The topic has already been mentioned in (for example #57), and I'm proposing an implementation for a way to be able to remove elements from the LaneletMap, without having to rebuild a complete map which can be costly for a large map.

I have added on the LaneletMap object the method removeIfUnused for each primitive.
RegulatoryElement are a bit tricky since they can reference a Primitive via the parameters without owning them. I provide in the RegulatoryElement a way to remove there references since not done in the removeIfUnused (as specified in the header documentation).

On our side, this feature is critical since we're trying to develop an editor for our use-case, and rebuilding a complete map when editing a primitive is not viable.

It's probably missing more tests and documentation to be ready, but I would like your opinion before going forward