### PR TITLE
Add BusLane to ParticipantMap and SpeedLimitLookup

### DIFF
--- a/lanelet2_traffic_rules/src/GenericTrafficRules.cpp
+++ b/lanelet2_traffic_rules/src/GenericTrafficRules.cpp
@@ -270,6 +270,8 @@ SpeedLimitInformation getSpeedLimitFromType(const AttributeMap& attributes, cons
       {{Value::Nonurban, Value::Highway}, &CountrySpeedLimits::vehicleNonurbanHighway},
       {{Value::Urban, Value::PlayStreet}, &CountrySpeedLimits::playStreet},
       {{Value::Nonurban, Value::PlayStreet}, &CountrySpeedLimits::playStreet},
+      {{Value::Urban, Value::BusLane}, &CountrySpeedLimits::vehicleUrbanRoad},
+      {{Value::Nonurban, Value::BusLane}, &CountrySpeedLimits::vehicleNonurbanRoad},
       {{Value::Urban, Value::Exit}, &CountrySpeedLimits::vehicleUrbanRoad},
   };
   if (participant == Participants::Pedestrian) {
@@ -334,6 +336,7 @@ Optional<bool> GenericTrafficRules::canPass(const std::string& type, const std::
       {Value::BicycleLane, {Participants::Bicycle}},
       {Value::PlayStreet, {Participants::Pedestrian, Participants::Bicycle, Participants::Vehicle}},
       {Value::EmergencyLane, {Participants::VehicleEmergency}},
+      {Value::BusLane, {Participants::VehicleBus, Participants::VehicleEmergency, Participants::VehicleTaxi}},
       {Value::Exit, {Participants::Pedestrian, Participants::Bicycle, Participants::Vehicle}},
       {Value::Walkway, {Participants::Pedestrian}},
       {Value::Crosswalk, {Participants::Pedestrian}},


### PR DESCRIPTION
According to the table under [Subtype and Location](https://github.com/fzi-forschungszentrum-informatik/Lanelet2/blob/master/lanelet2_core/doc/LaneletAndAreaTagging.md#subtype-and-location), **bus_lane** should be available for traffic participants: Bus, Emergency, Taxi. Currently, it is missing from the ParticipantsMap and, therefore, is denied for the routing.

1. Added bus_lane to ParticipantMap
   - Registers which participants are allowed on a bus_lane lanelet: Bus, Emergency, and Taxi vehicles.
   - This enables canPass() to correctly resolve access rights for bus lanes.
2. Added bus_lane to SpeedLimitLookup
   - Urban bus_lane maps to vehicleUrbanRoad (city speed limit, e.g. 50 km/h in Germany)
   - Nonurban bus_lane maps to vehicleNonurbanRoad (nonurban speed limit, e.g. 100 km/h in Germany)


Additional question, would it be reasonable to also add Bikes to urban bus lanes?