### PR TITLE
ci: update GitHub Actions runner from ubuntu-22.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -84,7 +84,7 @@ jobs:
       matrix:
         # test only on currently supported version
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        os: ["ubuntu-22.04", "ubuntu-24.04"]
+        os: ["ubuntu-24.04"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Restore wheel
@@ -132,7 +132,7 @@ jobs:
           password: ${{ secrets.PYPI_API_TOKEN }}
 
   deploy-pages:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.ref == 'refs/heads/master'
     concurrency: deploy-${{ github.ref }}
     steps:


### PR DESCRIPTION
## Summary
- Update GitHub Actions `runs-on` runners from `ubuntu-22.04` to `ubuntu-24.04`
- `ubuntu-22.04-m` and other variant runners are unchanged

## Test plan
- [ ] Verify CI workflows pass on ubuntu-24.04 runners

Made with [Cursor](https://cursor.com)