### PR TITLE
Support MSVC builds in lanelet2_routing

### DIFF
--- a/lanelet2_routing/CMakeLists.txt
+++ b/lanelet2_routing/CMakeLists.txt
@@ -3,6 +3,10 @@ set(MRT_PKG_VERSION 4.0.0)
 cmake_minimum_required(VERSION 3.5.1)
 project(lanelet2_routing)
 
+if(WIN32 AND MSVC)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 ###################
 ## Find packages ##
 ###################

--- a/lanelet2_routing/src/RouteBuilder.cpp
+++ b/lanelet2_routing/src/RouteBuilder.cpp
@@ -234,12 +234,14 @@ class PathsOutOfRouteFinder {
     auto isAdjacentToRoute = [&](LaneletVertexId v) {
       auto inEdges = boost::in_edges(v, g);
       auto outEdges = boost::out_edges(v, g);
-      constexpr auto Adjacent =
-          RelationType::Left | RelationType::Right | RelationType::AdjacentLeft | RelationType::AdjacentRight;
       return std::any_of(inEdges.first, inEdges.second,
-                         [&](auto e) { return hasRelation<Adjacent>(g, e) && has(*llts_, boost::source(e, g)); }) ||
+                         [&](auto e) { return hasRelation<RelationType::Left | RelationType::Right |
+                                                   RelationType::AdjacentLeft | RelationType::AdjacentRight>(g, e) &&
+                                             has(*llts_, boost::source(e, g)); }) ||
              std::any_of(outEdges.first, outEdges.second,
-                         [&](auto e) { return hasRelation<Adjacent>(g, e) && has(*llts_, boost::target(e, g)); });
+                         [&](auto e) { return hasRelation<RelationType::Left | RelationType::Right |
+                                                   RelationType::AdjacentLeft | RelationType::AdjacentRight>(g, e) &&
+                                             has(*llts_, boost::target(e, g)); });
     };
     return std::all_of(path.begin(), path.end(), isAdjacentToRoute);
   }


### PR DESCRIPTION
This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-lanelet2-routing.win.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: MSVC builds need exported symbols from the lanelet2_routing shared library for downstream consumers, and MSVC does not accept the intermediate `constexpr` variable as the non-type template argument in `RouteBuilder.cpp`. The symbol export is limited to WIN32/MSVC, and the template argument is expressed directly so the code remains portable across compilers.