### PR TITLE
Use /bigobj for lanelet2_python on MSVC

### DIFF
--- a/lanelet2_python/CMakeLists.txt
+++ b/lanelet2_python/CMakeLists.txt
@@ -55,6 +55,10 @@ mrt_add_library(${PROJECT_NAME}
     SOURCES ${PROJECT_SOURCE_FILES_SRC}
     )
 
+target_compile_options(${PROJECT_NAME} INTERFACE
+  $<$<CXX_COMPILER_ID:MSVC>:/bigobj>
+)
+
 #############
 ## Install ##
 #############


### PR DESCRIPTION
This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-lanelet2-python.win.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: lanelet2_python can produce large generated C++ translation units for MSVC. Adding `/bigobj` only for the MSVC compiler gives the object file enough sections while keeping the existing compile options unchanged for other toolchains.