### PR TITLE
Export lanelet2_traffic_rules symbols on Windows

### DIFF
--- a/lanelet2_traffic_rules/CMakeLists.txt
+++ b/lanelet2_traffic_rules/CMakeLists.txt
@@ -3,6 +3,10 @@ set(MRT_PKG_VERSION 4.0.0)
 cmake_minimum_required(VERSION 3.5.1)
 project(lanelet2_traffic_rules)
 
+if(WIN32 AND MSVC)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 ###################
 ## Find packages ##
 ###################


### PR DESCRIPTION
This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-lanelet2-traffic-rules.win.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: MSVC builds need exported symbols from the lanelet2_traffic_rules shared library for downstream consumers. Enabling `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` only for WIN32/MSVC keeps the existing behavior unchanged on other toolchains while making the Windows build export the required symbols.