### PR TITLE
Support MSVC builds in lanelet2_matching

### DIFF
--- a/lanelet2_matching/CMakeLists.txt
+++ b/lanelet2_matching/CMakeLists.txt
@@ -3,6 +3,10 @@ set(MRT_PKG_VERSION 4.0.0)
 cmake_minimum_required(VERSION 3.5.1)
 project(lanelet2_matching)
 
+if(WIN32 AND MSVC)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 ###################
 ## Find packages ##
 ###################
@@ -50,6 +54,10 @@ mrt_glob_files(PROJECT_SOURCE_FILES_SRC "src/*.cpp" "src/*.cu")
 mrt_add_library(${PROJECT_NAME}
     INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC}
     SOURCES ${PROJECT_SOURCE_FILES_SRC}
+    )
+
+target_compile_definitions(${PROJECT_NAME}
+    PUBLIC "$<$<CXX_COMPILER_ID:MSVC>:_USE_MATH_DEFINES>"
     )
 
 #############


### PR DESCRIPTION
This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-lanelet2-matching.win.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: MSVC consumers need exported symbols from the lanelet2_matching shared library, and `_USE_MATH_DEFINES` needs to be defined before consuming math constants from `<cmath>`. The symbol export is limited to WIN32/MSVC, and the compile definition is limited to the MSVC compiler so other platforms keep their current behavior.