### PR TITLE
Pixi CI + Improve lanelet2_core MSVC compatibility

### DIFF
--- a/.github/workflows/build-pixi.yaml
+++ b/.github/workflows/build-pixi.yaml
@@ -1,0 +1,35 @@
+name: pixi
+
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build-${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-64
+            runner: ubuntu-latest
+          - platform: osx-arm64
+            runner: macos-15
+          - platform: win-64
+            runner: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pixi
+        uses: prefix-dev/setup-pixi@v0.8.8
+        with:
+          pixi-version: v0.72.0
+          run-install: false
+
+      - name: Build workspace
+        run: pixi install

--- a/.github/workflows/build-pixi.yaml
+++ b/.github/workflows/build-pixi.yaml
@@ -1,6 +1,7 @@
 name: pixi
 
 on:
+  push:
   pull_request:
     branches:
       - master
@@ -13,15 +14,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rosdistro: [humble, jazzy, kilted, rolling]
+        rosdistro: [noetic, humble, jazzy, kilted, rolling]
         runner: [ubuntu-latest, macos-15, windows-latest]
+        exclude:
+          - rosdistro: noetic
+            runner: windows-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.8.8
+        uses: prefix-dev/setup-pixi@v0.10.0
         with:
           pixi-version: v0.72.0
           run-install: false

--- a/.github/workflows/build-pixi.yaml
+++ b/.github/workflows/build-pixi.yaml
@@ -8,18 +8,13 @@ on:
 
 jobs:
   build:
-    name: build-${{ matrix.platform }}
+    name: build-${{ matrix.rosdistro }}-${{ matrix.runner }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: linux-64
-            runner: ubuntu-latest
-          - platform: osx-arm64
-            runner: macos-15
-          - platform: win-64
-            runner: windows-latest
+        rosdistro: [humble, jazzy, kilted, rolling]
+        runner: [ubuntu-latest, macos-15, windows-latest]
 
     steps:
       - name: Checkout
@@ -32,4 +27,4 @@ jobs:
           run-install: false
 
       - name: Build workspace
-        run: pixi install
+        run: pixi install --environment ${{ matrix.rosdistro }}

--- a/.github/workflows/build-pixi.yaml
+++ b/.github/workflows/build-pixi.yaml
@@ -16,9 +16,6 @@ jobs:
       matrix:
         rosdistro: [noetic, humble, jazzy, kilted, rolling]
         runner: [ubuntu-latest, macos-15, windows-latest]
-        exclude:
-          - rosdistro: noetic
-            runner: windows-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -40,10 +40,10 @@ jobs:
     steps:
       - name: Setup docker buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Create build container
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           builder: ${{ steps.buildx.outputs.name }}
           file: .github/conan_dockerfile/Dockerfile
@@ -73,7 +73,7 @@ jobs:
             sudo cp -r $HOME/dist/* /dist
 
       - name: Store wheel
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dist-${{ matrix.python-version }}
           path: dist/
@@ -88,13 +88,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Restore wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: dist-*
           merge-multiple: true
           path: dist/
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install wheel 24.04
@@ -114,14 +114,14 @@ jobs:
     needs: [build, test]
     steps:
       - name: Restore wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: dist-*
           merge-multiple: true
           path: dist/
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*
 
@@ -136,10 +136,10 @@ jobs:
     if: github.ref == 'refs/heads/master'
     concurrency: deploy-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: set up python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,6 +181,10 @@ jobs:
           docker rm -f lanelet2_test_${{ matrix.rosdistro }};
           docker rm -f lanelet2_test_${{ matrix.rosdistro }}_lcov;
 
+      - name: Install lcov
+        if: ${{ matrix.rosdistro == 'noetic' }}
+        run: sudo apt-get update && sudo apt-get install --yes lcov
+
       - name: Report code coverage
         uses: zgosalvez/github-actions-report-lcov@v7.1.0
         if: ${{ matrix.rosdistro == 'noetic' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,7 +182,7 @@ jobs:
           docker rm -f lanelet2_test_${{ matrix.rosdistro }}_lcov;
 
       - name: Report code coverage
-        uses: immel-f/github-actions-report-lcov@v0.1.13
+        uses: zgosalvez/github-actions-report-lcov@v7.1.0
         if: ${{ matrix.rosdistro == 'noetic' }}
         with:
           coverage-files: ./lcov/full_coverage.lcov

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -175,6 +175,7 @@ jobs:
           docker run -i --name lanelet2_test_${{ matrix.rosdistro }}_lcov lanelet2_${{ matrix.rosdistro }}_post_run /home/developer/workspace/src/lanelet2/.github/lcov_merge.bash;
           mkdir -p ./lcov;
           docker cp lanelet2_test_${{ matrix.rosdistro }}_lcov:$(docker inspect --format='{{.Config.WorkingDir}}' lanelet2_test_${{ matrix.rosdistro }}_lcov)/lcov/full_coverage.lcov ./lcov/full_coverage.lcov;
+          sed -i "s|/home/developer/workspace/src/lanelet2|${GITHUB_WORKSPACE}|g" ./lcov/full_coverage.lcov;
 
       - name: Cleanup Docker Container
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,16 +19,16 @@ jobs:
     steps:
       - name: Setup docker buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Setup docker cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: /tmp/.docker-cache
           key: ${{runner.os}}-docker-humble
 
       - name: Build dependencies
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           builder: ${{ steps.buildx.outputs.name }}
           tags: lanelet2_src
@@ -53,16 +53,16 @@ jobs:
     steps:
       - name: Setup docker buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Setup docker cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: /tmp/.docker-cache
           key: ${{runner.os}}-docker-humble
 
       - name: Build dependencies
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           builder: ${{ steps.buildx.outputs.name }}
           tags: lanelet2_src
@@ -102,20 +102,20 @@ jobs:
       - name: Delete unnecessary tools folder
         run: rm -rf /opt/hostedtoolcache
       
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         
       - name: Setup docker buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Setup docker cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: /tmp/.docker-cache
           key: ${{runner.os}}-docker-${{ matrix.rosdistro }}
 
       - name: Build dependencies
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           builder: ${{ steps.buildx.outputs.name }}
           tags: lanelet2_base:${{ matrix.rosdistro }}
@@ -129,7 +129,7 @@ jobs:
           target: lanelet2_deps
 
       - name: Build Lanelet2
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         if: ${{ matrix.rosdistro == 'noetic' }}
         with:
           builder: ${{ steps.buildx.outputs.name }}
@@ -144,7 +144,7 @@ jobs:
           target: lanelet2
 
       - name: Build Lanelet2 (skip lcov)
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         if: ${{ matrix.rosdistro == 'jazzy' || matrix.rosdistro == 'humble' || matrix.rosdistro == 'galactic' }}
         with:
           builder: ${{ steps.buildx.outputs.name }}
@@ -220,10 +220,10 @@ jobs:
     steps:
       - name: Setup docker buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
 
       - name: Build dependencies
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v7
         with:
           builder: ${{ steps.buildx.outputs.name }}
           file: .github/conan_dockerfile/Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 setup.py
 CMakeLists.txt.user
 site
+.pixi/
+pixi.lock

--- a/lanelet2_core/CMakeLists.txt
+++ b/lanelet2_core/CMakeLists.txt
@@ -11,6 +11,9 @@ endif()
 ## Find packages ##
 ###################
 find_package(mrt_cmake_modules REQUIRED)
+if(WIN32 AND ROS_VERSION EQUAL 1)
+  set(MRT_CMAKE_ENV ${CATKIN_ENV})
+endif()
 include(UseMrtStdCompilerFlags)
 include(GatherDeps)
 

--- a/lanelet2_core/CMakeLists.txt
+++ b/lanelet2_core/CMakeLists.txt
@@ -3,6 +3,10 @@ set(MRT_PKG_VERSION 4.0.0)
 cmake_minimum_required(VERSION 3.5.1)
 project(lanelet2_core)
 
+if(WIN32 AND MSVC)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 ###################
 ## Find packages ##
 ###################

--- a/lanelet2_core/CMakeLists.txt
+++ b/lanelet2_core/CMakeLists.txt
@@ -68,7 +68,7 @@ mrt_install(PROGRAMS scripts FILES res data ${PROJECT_INSTALL_FILES})
 ## Testing ##
 #############
 # Add test targets for cpp and python tests
-if (CATKIN_ENABLE_TESTING)
+if (CATKIN_ENABLE_TESTING AND NOT CATKIN_SKIP_TESTING)
     mrt_add_tests(test)
     mrt_add_nosetests(test)
 endif()

--- a/lanelet2_core/CMakeLists.txt
+++ b/lanelet2_core/CMakeLists.txt
@@ -55,6 +55,7 @@ mrt_add_library(${PROJECT_NAME}
     INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC}
     SOURCES ${PROJECT_SOURCE_FILES_SRC}
     )
+target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen)
 
 #############
 ## Install ##

--- a/lanelet2_core/include/lanelet2_core/Forward.h
+++ b/lanelet2_core/include/lanelet2_core/Forward.h
@@ -199,6 +199,9 @@ using Id = int64_t;
 constexpr Id InvalId = 0;  //!< indicates a primitive that is not part of a map
 using Ids = std::vector<Id>;
 
+constexpr double Pi = 3.14159265358979323846;
+constexpr double PiQuarter = Pi / 4.;
+
 // Velocity definitions
 namespace units {
 using MPS = boost::units::unit<boost::units::velocity_dimension, boost::units::si::system>;

--- a/lanelet2_core/include/lanelet2_core/geometry/Area.h
+++ b/lanelet2_core/include/lanelet2_core/geometry/Area.h
@@ -12,8 +12,8 @@ namespace geometry {
  * @param point point to check
  * @return true if the point is within or at the border, false otherwise
  */
-template <typename AreaT>
-IfAr<AreaT, bool> inside(const AreaT& area, const BasicPoint2d& point);
+template <typename AreaT, IfAr<AreaT, int> = 0>
+bool inside(const AreaT& area, const BasicPoint2d& point);
 
 /**
  * @brief calculates an up-right 2d bounding box
@@ -22,30 +22,30 @@ IfAr<AreaT, bool> inside(const AreaT& area, const BasicPoint2d& point);
  *
  * Linear on number of points.
  */
-template <typename AreaT>
-IfAr<AreaT, BoundingBox2d> boundingBox2d(const AreaT& area);
+template <typename AreaT, IfAr<AreaT, int> = 0>
+BoundingBox2d boundingBox2d(const AreaT& area);
 
 /**
  * @brief calculates 3d bounding box
  * @param area area to calculate it from.
  * @return the bounding box
  */
-template <typename AreaT>
-IfAr<AreaT, BoundingBox3d> boundingBox3d(const AreaT& area);
+template <typename AreaT, IfAr<AreaT, int> = 0>
+BoundingBox3d boundingBox3d(const AreaT& area);
 
 //! test whether two areas intersect in 2d.
-template <typename Area1T, typename Area2T>
-IfAr<Area1T, bool> intersects2d(const Area1T& area, const Area2T& otherArea);
+template <typename Area1T, typename Area2T, IfAr<Area1T, int> = 0>
+bool intersects2d(const Area1T& area, const Area2T& otherArea);
 
 //! test whether two areas overlap in 2d (common area < 0).
 //! This is an approximation that ignores the holes of the areas!
-template <typename AreaT>
-IfAr<AreaT, bool> overlaps2d(const AreaT& area, const AreaT& otherArea);
+template <typename AreaT, IfAr<AreaT, int> = 0>
+bool overlaps2d(const AreaT& area, const AreaT& otherArea);
 
 //! test whether two areas overlap in 3d.
 //! This is an approximation that uses the overlap of the outer bound
-template <typename AreaT>
-IfAr<AreaT, bool> overlaps3d(const AreaT& area, const AreaT& otherArea, double heightTolerance);
+template <typename AreaT, IfAr<AreaT, int> = 0>
+bool overlaps3d(const AreaT& area, const AreaT& otherArea, double heightTolerance);
 
 //! test whether an area and a lanelet overlap in 2d
 //! This is an approximation that uses the overlap of the outer bound

--- a/lanelet2_core/include/lanelet2_core/geometry/Lanelet.h
+++ b/lanelet2_core/include/lanelet2_core/geometry/Lanelet.h
@@ -10,8 +10,8 @@ namespace geometry {
  * @param point point to check
  * @return true if the point is within or at the border, false otherwise
  */
-template <typename LaneletT>
-IfLL<LaneletT, bool> inside(const LaneletT& lanelet, const BasicPoint2d& point);
+template <typename LaneletT, IfLL<LaneletT, int> = 0>
+bool inside(const LaneletT& lanelet, const BasicPoint2d& point);
 
 /**
  * @brief approximates length by sampling points along left bound
@@ -68,16 +68,16 @@ double distanceToCenterline3d(const LaneletT& lanelet, const BasicPoint3d& point
  *
  * Linear on number of points.
  */
-template <typename LaneletT>
-IfLL<LaneletT, BoundingBox2d> boundingBox2d(const LaneletT& lanelet);
+template <typename LaneletT, IfLL<LaneletT, int> = 0>
+BoundingBox2d boundingBox2d(const LaneletT& lanelet);
 
 /**
  * @brief calculates 3d bounding box
  * @param lanelet lanelet to calculate it from.
  * @return the bounding box
  */
-template <typename LaneletT>
-IfLL<LaneletT, BoundingBox3d> boundingBox3d(const LaneletT& lanelet);
+template <typename LaneletT, IfLL<LaneletT, int> = 0>
+BoundingBox3d boundingBox3d(const LaneletT& lanelet);
 
 /**
  * @brief test whether two lanelets intersect in 2d.
@@ -89,8 +89,8 @@ IfLL<LaneletT, BoundingBox3d> boundingBox3d(const LaneletT& lanelet);
  * This also returns true if the two lanelets only touch each other. Use
  * overlaps if you do not want this.
  */
-template <typename Lanelet1T, typename Lanelet2T>
-IfLL<Lanelet1T, bool> intersects2d(const Lanelet1T& lanelet, const Lanelet2T& otherLanelet);
+template <typename Lanelet1T, typename Lanelet2T, IfLL<Lanelet1T, int> = 0>
+bool intersects2d(const Lanelet1T& lanelet, const Lanelet2T& otherLanelet);
 
 /**
  * @brief test whether two lanelets overlap in 2d.

--- a/lanelet2_core/include/lanelet2_core/geometry/Polygon.h
+++ b/lanelet2_core/include/lanelet2_core/geometry/Polygon.h
@@ -245,14 +245,14 @@ IfPoly<Polygon3dT, double> distanceToBorder3d(const Polygon3dT& poly1, const Pol
  *
  * @return The enclosing axis aligned bounding box of all points.
  */
-template <typename Polygon3dT>
-IfPoly<Polygon3dT, BoundingBox3d> boundingBox3d(const Polygon3dT& polygon);
+template <typename Polygon3dT, IfPoly<Polygon3dT, int> = 0>
+BoundingBox3d boundingBox3d(const Polygon3dT& polygon);
 
-template <typename Polygon2dT>
-IfPoly<Polygon2dT, BoundingBox2d> boundingBox2d(const Polygon2dT& polygon);
+template <typename Polygon2dT, IfPoly<Polygon2dT, int> = 0>
+BoundingBox2d boundingBox2d(const Polygon2dT& polygon);
 
-template <typename Polygon3dT>
-IfPoly<Polygon3dT, BoundingBox3d> boundingBox3d(const Polygon3dT& polygon) {
+template <typename Polygon3dT, IfPoly<Polygon3dT, int>>
+BoundingBox3d boundingBox3d(const Polygon3dT& polygon) {
   static_assert(traits::is3D<Polygon3dT>(), "Please call this function with a 3D type!");
   BoundingBox3d bb;
   for (const auto& p : polygon) {
@@ -261,8 +261,8 @@ IfPoly<Polygon3dT, BoundingBox3d> boundingBox3d(const Polygon3dT& polygon) {
   return bb;
 }
 
-template <typename Polygon2dT>
-IfPoly<Polygon2dT, BoundingBox2d> boundingBox2d(const Polygon2dT& polygon) {
+template <typename Polygon2dT, IfPoly<Polygon2dT, int>>
+BoundingBox2d boundingBox2d(const Polygon2dT& polygon) {
   static_assert(traits::is2D<Polygon2dT>(), "Please call this function with a 2D type!");
   BoundingBox2d bb;
   for (const auto& p : polygon) {

--- a/lanelet2_core/include/lanelet2_core/geometry/impl/Area.h
+++ b/lanelet2_core/include/lanelet2_core/geometry/impl/Area.h
@@ -16,36 +16,36 @@ struct GetGeometry<T, IfAr<T, void>> {
 };
 }  // namespace internal
 
-template <typename AreaT>
-IfAr<AreaT, bool> inside(const AreaT& area, const BasicPoint2d& point) {
+template <typename AreaT, IfAr<AreaT, int>>
+bool inside(const AreaT& area, const BasicPoint2d& point) {
   return boost::geometry::covered_by(point, area.basicPolygonWithHoles2d());
 }
 
-template <typename AreaT>
-IfAr<AreaT, BoundingBox2d> boundingBox2d(const AreaT& area) {
+template <typename AreaT, IfAr<AreaT, int>>
+BoundingBox2d boundingBox2d(const AreaT& area) {
   return boundingBox2d(traits::to2D(area.outerBoundPolygon()));
 }
 
-template <typename AreaT>
-IfAr<AreaT, BoundingBox3d> boundingBox3d(const AreaT& area) {
+template <typename AreaT, IfAr<AreaT, int>>
+BoundingBox3d boundingBox3d(const AreaT& area) {
   return boundingBox3d(area.outerBoundPolygon());
 }
 
-template <typename Area1T, typename Area2T>
-IfAr<Area1T, bool> intersects2d(const Area1T& area, const Area2T& otherArea) {
+template <typename Area1T, typename Area2T, IfAr<Area1T, int>>
+bool intersects2d(const Area1T& area, const Area2T& otherArea) {
   if (area == otherArea) {
     return true;
   }
   return intersects(area.basicPolygonWithHoles2d(), otherArea.basicPolygonWithHoles2d());
 }
 
-template <typename AreaT>
-IfAr<AreaT, bool> overlaps2d(const AreaT& area, const AreaT& otherArea) {
+template <typename AreaT, IfAr<AreaT, int>>
+bool overlaps2d(const AreaT& area, const AreaT& otherArea) {
   return overlaps2d(traits::to2D(area.outerBoundPolygon()), traits::to2D(otherArea.outerBoundPolygon()));
 }
 
-template <typename AreaT>
-IfAr<AreaT, bool> overlaps3d(const AreaT& area, const AreaT& otherArea, double heightTolerance) {
+template <typename AreaT, IfAr<AreaT, int>>
+bool overlaps3d(const AreaT& area, const AreaT& otherArea, double heightTolerance) {
   return overlaps3d(area.outerBoundPolygon(), otherArea.outerBoundPolygon(), heightTolerance);
 }
 

--- a/lanelet2_core/include/lanelet2_core/geometry/impl/Lanelet.h
+++ b/lanelet2_core/include/lanelet2_core/geometry/impl/Lanelet.h
@@ -21,8 +21,8 @@ struct GetGeometry<T, IfLL<T, void>> {
 };
 }  // namespace internal
 
-template <typename LaneletT>
-IfLL<LaneletT, bool> inside(const LaneletT& lanelet, const BasicPoint2d& point) {
+template <typename LaneletT, IfLL<LaneletT, int>>
+bool inside(const LaneletT& lanelet, const BasicPoint2d& point) {
   return boost::geometry::covered_by(point, lanelet.polygon2d());
 }
 
@@ -36,22 +36,22 @@ double distanceToCenterline3d(const LaneletT& lanelet, const BasicPoint3d& point
   return distance(lanelet.centerline3d(), point);
 }
 
-template <typename LaneletT>
-IfLL<LaneletT, BoundingBox2d> boundingBox2d(const LaneletT& lanelet) {
+template <typename LaneletT, IfLL<LaneletT, int>>
+BoundingBox2d boundingBox2d(const LaneletT& lanelet) {
   BoundingBox2d bb = boundingBox2d(lanelet.leftBound2d());
   bb.extend(boundingBox2d(lanelet.rightBound2d()));
   return bb;
 }
 
-template <typename LaneletT>
-IfLL<LaneletT, BoundingBox3d> boundingBox3d(const LaneletT& lanelet) {
+template <typename LaneletT, IfLL<LaneletT, int>>
+BoundingBox3d boundingBox3d(const LaneletT& lanelet) {
   BoundingBox3d bb = boundingBox3d(lanelet.leftBound3d());
   bb.extend(boundingBox3d(lanelet.rightBound3d()));
   return bb;
 }
 
-template <typename Lanelet1T, typename Lanelet2T>
-IfLL<Lanelet1T, bool> intersects2d(const Lanelet1T& lanelet, const Lanelet2T& otherLanelet) {
+template <typename Lanelet1T, typename Lanelet2T, IfLL<Lanelet1T, int>>
+bool intersects2d(const Lanelet1T& lanelet, const Lanelet2T& otherLanelet) {
   if (lanelet.constData() == otherLanelet.constData()) {
     return true;
   }

--- a/lanelet2_core/include/lanelet2_core/geometry/impl/LineString.h
+++ b/lanelet2_core/include/lanelet2_core/geometry/impl/LineString.h
@@ -475,8 +475,8 @@ inline BasicLineString2d shiftConvexSharp(const LineString2dT& lineString, const
   }
   BasicPoint2d firstP = shiftPerpendicular(lineString, idx, distance, true, pv);
   BasicPoint2d lastP = shiftPerpendicular(lineString, idx, distance, false, pv);
-  auto alpha = M_PI - std::acos(pv.following.dot(pv.preceding) / (pv.preceding.norm() * pv.following.norm()));
-  auto overshoot = distance * std::tan(M_PI_4 - alpha / 4);
+  auto alpha = Pi - std::acos(pv.following.dot(pv.preceding) / (pv.preceding.norm() * pv.following.norm()));
+  auto overshoot = distance * std::tan(PiQuarter - alpha / 4);
   return {firstP + pv.preceding.normalized() * overshoot, lastP - pv.following.normalized() * overshoot};
 }
 

--- a/lanelet2_core/include/lanelet2_core/geometry/impl/LineString.h
+++ b/lanelet2_core/include/lanelet2_core/geometry/impl/LineString.h
@@ -799,8 +799,7 @@ IfLS<LineString3dT, std::pair<BasicPoint3d, BasicPoint3d>> projectedPoint3d(cons
   return internal::projectedPoint3d(traits::toHybrid(l1), traits::toHybrid(l2));
 }
 
-template <typename LineString3d1T, typename LineString3d2T,
-          IfLS2<LineString3d1T, LineString3d2T, int> = 0>
+template <typename LineString3d1T, typename LineString3d2T, IfLS2<LineString3d1T, LineString3d2T, int> = 0>
 double distance3d(const LineString3d1T& l1, const LineString3d2T& l2) {
   auto projPoint = internal::projectedPoint3d(traits::toHybrid(traits::to3D(l1)), traits::toHybrid(traits::to3D(l2)));
   return (projPoint.first - projPoint.second).norm();

--- a/lanelet2_core/include/lanelet2_core/geometry/impl/LineString.h
+++ b/lanelet2_core/include/lanelet2_core/geometry/impl/LineString.h
@@ -799,8 +799,9 @@ IfLS<LineString3dT, std::pair<BasicPoint3d, BasicPoint3d>> projectedPoint3d(cons
   return internal::projectedPoint3d(traits::toHybrid(l1), traits::toHybrid(l2));
 }
 
-template <typename LineString3d1T, typename LineString3d2T>
-IfLS2<LineString3d1T, LineString3d2T, double> distance3d(const LineString3d1T& l1, const LineString3d2T& l2) {
+template <typename LineString3d1T, typename LineString3d2T,
+          IfLS2<LineString3d1T, LineString3d2T, int> = 0>
+double distance3d(const LineString3d1T& l1, const LineString3d2T& l2) {
   auto projPoint = internal::projectedPoint3d(traits::toHybrid(traits::to3D(l1)), traits::toHybrid(traits::to3D(l2)));
   return (projPoint.first - projPoint.second).norm();
 }

--- a/lanelet2_core/include/lanelet2_core/primitives/Polygon.h
+++ b/lanelet2_core/include/lanelet2_core/primitives/Polygon.h
@@ -394,8 +394,7 @@ inline BasicPolygon2d to2D<BasicPolygon3d>(const BasicPolygon3d& primitive) {
   return p2d;
 }
 
-template <typename PolygonT,
-          std::enable_if_t<traits::isPolygonT<PolygonT>(), int> = 0>
+template <typename PolygonT, std::enable_if_t<traits::isPolygonT<PolygonT>(), int> = 0>
 BasicPolygon2d toBasicPolygon2d(const PolygonT& t) {
   return traits::to2D(t).basicPolygon();
 }
@@ -412,8 +411,7 @@ inline BasicPolygon2d toBasicPolygon2d<BasicPolygon3d>(const BasicPolygon3d& t) 
 
 inline BasicPolygon2d toBasicPolygon2d(BasicPolygon2d&& t) { return std::move(t); }
 
-template <typename PolygonT,
-          std::enable_if_t<traits::isPolygonT<PolygonT>(), int> = 0>
+template <typename PolygonT, std::enable_if_t<traits::isPolygonT<PolygonT>(), int> = 0>
 BasicPolygon3d toBasicPolygon3d(const PolygonT& t) {
   return traits::to3D(t).basicPolygon();
 }

--- a/lanelet2_core/include/lanelet2_core/primitives/Polygon.h
+++ b/lanelet2_core/include/lanelet2_core/primitives/Polygon.h
@@ -394,8 +394,9 @@ inline BasicPolygon2d to2D<BasicPolygon3d>(const BasicPolygon3d& primitive) {
   return p2d;
 }
 
-template <typename PolygonT>
-std::enable_if_t<traits::isPolygonT<PolygonT>(), BasicPolygon2d> toBasicPolygon2d(const PolygonT& t) {
+template <typename PolygonT,
+          std::enable_if_t<traits::isPolygonT<PolygonT>(), int> = 0>
+BasicPolygon2d toBasicPolygon2d(const PolygonT& t) {
   return traits::to2D(t).basicPolygon();
 }
 
@@ -411,8 +412,9 @@ inline BasicPolygon2d toBasicPolygon2d<BasicPolygon3d>(const BasicPolygon3d& t) 
 
 inline BasicPolygon2d toBasicPolygon2d(BasicPolygon2d&& t) { return std::move(t); }
 
-template <typename PolygonT>
-std::enable_if_t<traits::isPolygonT<PolygonT>(), BasicPolygon3d> toBasicPolygon3d(const PolygonT& t) {
+template <typename PolygonT,
+          std::enable_if_t<traits::isPolygonT<PolygonT>(), int> = 0>
+BasicPolygon3d toBasicPolygon3d(const PolygonT& t) {
   return traits::to3D(t).basicPolygon();
 }
 

--- a/lanelet2_core/include/lanelet2_core/utility/HybridMap.h
+++ b/lanelet2_core/include/lanelet2_core/utility/HybridMap.h
@@ -65,7 +65,7 @@ void replaceIterator(Vector& v, const Iterator& replace, const Iterator& by) {
  */
 template <typename ValueT, typename PairArrayT, PairArrayT PairArray>
 class HybridMap {
-  using Array = detail::ArrayView<PairArrayT, PairArray>;
+  using Array = lanelet::detail::ArrayView<PairArrayT, PairArray>;
 
  public:
   using Map = std::map<std::string, ValueT>;
@@ -82,19 +82,19 @@ class HybridMap {
   HybridMap() noexcept = default;
   HybridMap(HybridMap&& rhs) noexcept : m_(std::move(rhs.m_)), v_{std::move(rhs.v_)} {
     // move invalidates no iterators except end
-    detail::replaceIterator(v_, rhs.m_.end(), m_.end());
+    lanelet::detail::replaceIterator(v_, rhs.m_.end(), m_.end());
   }
   HybridMap& operator=(HybridMap&& rhs) noexcept {
     m_ = std::move(rhs.m_);
     v_ = std::move(rhs.v_);
     // move invalidates no iterators except end
-    detail::replaceIterator(v_, rhs.m_.end(), m_.end());
+    lanelet::detail::replaceIterator(v_, rhs.m_.end(), m_.end());
     return *this;
   }
-  HybridMap(const HybridMap& rhs) : m_{rhs.m_}, v_{detail::copyIterators(rhs.v_, rhs.m_, m_)} {}
+  HybridMap(const HybridMap& rhs) : m_{rhs.m_}, v_{lanelet::detail::copyIterators(rhs.v_, rhs.m_, m_)} {}
   HybridMap& operator=(const HybridMap& rhs) {
     m_ = rhs.m_;
-    v_ = detail::copyIterators(rhs.v_, rhs.m_, m_);
+    v_ = lanelet::detail::copyIterators(rhs.v_, rhs.m_, m_);
     return *this;
   }
   HybridMap(const std::initializer_list<std::pair<const std::string, ValueT>>& list) {

--- a/lanelet2_core/package.xml
+++ b/lanelet2_core/package.xml
@@ -16,7 +16,7 @@
   <buildtool_depend>mrt_cmake_modules</buildtool_depend>
   <buildtool_export_depend>mrt_cmake_modules</buildtool_export_depend>
   <test_depend>gtest</test_depend>
-  <depend version_lt="5">eigen</depend>
+  <depend>eigen</depend>
   <depend>boost</depend>
 
   <export>

--- a/lanelet2_core/package.xml
+++ b/lanelet2_core/package.xml
@@ -16,7 +16,7 @@
   <buildtool_depend>mrt_cmake_modules</buildtool_depend>
   <buildtool_export_depend>mrt_cmake_modules</buildtool_export_depend>
   <test_depend>gtest</test_depend>
-  <depend>eigen</depend>
+  <depend version_lt="5">eigen</depend>
   <depend>boost</depend>
 
   <export>

--- a/lanelet2_core/src/LaneletMap.cpp
+++ b/lanelet2_core/src/LaneletMap.cpp
@@ -312,7 +312,7 @@ struct PrimitiveLayer<Point3d>::Tree {
   using TreeNode = std::pair<BasicPoint2d, Point3d>;
   using RTree = bgi::rtree<TreeNode, bgi::quadratic<16>>;
   static TreeNode treeNode(const Point3d& p) { return {Point2d(p).basicPoint(), p}; }
-  explicit Tree(const PrimitiveLayer::Map& primitives) {
+  explicit Tree(const PrimitiveLayer<Point3d>::Map& primitives) {
     std::vector<TreeNode> nodes;
     nodes.reserve(primitives.size());
     std::transform(primitives.begin(), primitives.end(), std::back_inserter(nodes),

--- a/lanelet2_examples/CMakeLists.txt
+++ b/lanelet2_examples/CMakeLists.txt
@@ -7,6 +7,9 @@ project(lanelet2_examples)
 ## Find packages ##
 ###################
 find_package(mrt_cmake_modules REQUIRED)
+if(WIN32 AND ROS_VERSION EQUAL 1)
+  set(MRT_CMAKE_ENV ${CATKIN_ENV})
+endif()
 include(UseMrtStdCompilerFlags)
 include(GatherDeps)
 

--- a/lanelet2_examples/CMakeLists.txt
+++ b/lanelet2_examples/CMakeLists.txt
@@ -53,7 +53,7 @@ mrt_install(PROGRAMS scripts FILES res data ${PROJECT_INSTALL_FILES})
 ## Testing ##
 #############
 # Add test targets for cpp and python tests
-if (CATKIN_ENABLE_TESTING)
+if (CATKIN_ENABLE_TESTING AND NOT CATKIN_SKIP_TESTING)
     mrt_add_tests(test)
     mrt_add_nosetests(test)
 endif()

--- a/lanelet2_examples/src/04_reading_and_writing/main.cpp
+++ b/lanelet2_examples/src/04_reading_and_writing/main.cpp
@@ -15,12 +15,20 @@ namespace {
 std::string exampleMapPath = std::string(PKG_DIR) + "/../lanelet2_maps/res/mapping_example.osm";
 
 std::string tempfile(const std::string& name) {
+#ifdef _WIN32
+  char tmpName[L_tmpnam_s];
+  if (tmpnam_s(tmpName, sizeof(tmpName)) != 0) {
+    throw lanelet::IOError("Failed to open a temporary file for writing");
+  }
+  return std::string(tmpName) + '_' + name;
+#else
   char tmpDir[] = "/tmp/lanelet2_example_XXXXXX";
   auto* file = mkdtemp(tmpDir);
   if (file == nullptr) {
     throw lanelet::IOError("Failed to open a temporary file for writing");
   }
   return std::string(file) + '/' + name;
+#endif
 }
 }  // namespace
 

--- a/lanelet2_examples/src/07_matching/main.cpp
+++ b/lanelet2_examples/src/07_matching/main.cpp
@@ -51,12 +51,12 @@ MapAndObject getSampleMapAndObject() {
   // create an object
   matching::ObjectWithCovariance2d obj;
   obj.pose.translation() = map->pointLayer.get(41656).basicPoint2d();
-  obj.pose.linear() = Eigen::Rotation2D<double>(150. / 180. * M_PI).matrix();
+  obj.pose.linear() = Eigen::Rotation2D<double>(150. / 180. * Pi).matrix();
   obj.absoluteHull = absoluteHull(
       matching::Hull2d{BasicPoint2d{-1, -0.9}, BasicPoint2d{2, -0.9}, BasicPoint2d{2, 0.9}, BasicPoint2d{1, 0.9}},
       obj.pose);
   obj.positionCovariance = matching::PositionCovariance2d::Identity() * 2.;
-  obj.vonMisesKappa = 1. / (10. / 180. * M_PI);  // covariance of 10 degrees
+  obj.vonMisesKappa = 1. / (10. / 180. * Pi);  // covariance of 10 degrees
 
   return MapAndObject{map, obj};
 }

--- a/lanelet2_io/CMakeLists.txt
+++ b/lanelet2_io/CMakeLists.txt
@@ -63,7 +63,7 @@ mrt_install(PROGRAMS scripts FILES res data ${PROJECT_INSTALL_FILES})
 ## Testing ##
 #############
 # Add test targets for cpp and python tests
-if (CATKIN_ENABLE_TESTING)
+if (CATKIN_ENABLE_TESTING AND NOT CATKIN_SKIP_TESTING)
     mrt_add_tests(test)
     mrt_add_nosetests(test)
 endif()

--- a/lanelet2_io/CMakeLists.txt
+++ b/lanelet2_io/CMakeLists.txt
@@ -3,10 +3,17 @@ set(MRT_PKG_VERSION 4.0.0)
 cmake_minimum_required(VERSION 3.5.1)
 project(lanelet2_io)
 
+if(WIN32 AND MSVC)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 ###################
 ## Find packages ##
 ###################
 find_package(mrt_cmake_modules REQUIRED)
+if(WIN32 AND ROS_VERSION EQUAL 1)
+  set(MRT_CMAKE_ENV ${CATKIN_ENV})
+endif()
 include(UseMrtStdCompilerFlags)
 include(GatherDeps)
 

--- a/lanelet2_io/include/lanelet2_io/Projection.h
+++ b/lanelet2_io/include/lanelet2_io/Projection.h
@@ -55,16 +55,16 @@ class SphericalMercatorProjector : public Projector {
  public:
   using Projector::Projector;
   BasicPoint3d forward(const GPSPoint& p) const override {
-    const auto scale = std::cos(origin().position.lat * M_PI / 180.0);
-    const double x{scale * p.lon * M_PI * EarthRadius / 180.0};
-    const double y{scale * EarthRadius * std::log(std::tan((90.0 + p.lat) * M_PI / 360.0))};
+    const auto scale = std::cos(origin().position.lat * Pi / 180.0);
+    const double x{scale * p.lon * Pi * EarthRadius / 180.0};
+    const double y{scale * EarthRadius * std::log(std::tan((90.0 + p.lat) * Pi / 360.0))};
     return {x, y, p.ele};
   }
 
   GPSPoint reverse(const BasicPoint3d& p) const override {
-    const double scale = std::cos(origin().position.lat * M_PI / 180.0);
-    const double lon = p.x() * 180.0 / (M_PI * EarthRadius * scale);
-    const double lat = 360.0 * std::atan(std::exp(p.y() / (EarthRadius * scale))) / M_PI - 90.0;
+    const double scale = std::cos(origin().position.lat * Pi / 180.0);
+    const double lon = p.x() * 180.0 / (Pi * EarthRadius * scale);
+    const double lat = 360.0 * std::atan(std::exp(p.y() / (EarthRadius * scale))) / Pi - 90.0;
     return {lat, lon, p.z()};
   }
 

--- a/lanelet2_maps/CMakeLists.txt
+++ b/lanelet2_maps/CMakeLists.txt
@@ -54,7 +54,7 @@ mrt_install(PROGRAMS scripts FILES res data ${PROJECT_INSTALL_FILES})
 ## Testing ##
 #############
 # Add test targets for cpp and python tests
-if (CATKIN_ENABLE_TESTING)
+if (CATKIN_ENABLE_TESTING AND NOT CATKIN_SKIP_TESTING)
     mrt_add_tests(test)
     mrt_add_nosetests(test)
 endif()

--- a/lanelet2_maps/CMakeLists.txt
+++ b/lanelet2_maps/CMakeLists.txt
@@ -7,6 +7,9 @@ project(lanelet2_maps)
 ## Find packages ##
 ###################
 find_package(mrt_cmake_modules REQUIRED)
+if(WIN32 AND ROS_VERSION EQUAL 1)
+  set(MRT_CMAKE_ENV ${CATKIN_ENV})
+endif()
 include(UseMrtStdCompilerFlags)
 include(GatherDeps)
 

--- a/lanelet2_matching/CMakeLists.txt
+++ b/lanelet2_matching/CMakeLists.txt
@@ -63,7 +63,7 @@ mrt_install(PROGRAMS scripts FILES res data ${PROJECT_INSTALL_FILES})
 ## Testing ##
 #############
 # Add test targets for cpp and python tests
-if (CATKIN_ENABLE_TESTING)
+if (CATKIN_ENABLE_TESTING AND NOT CATKIN_SKIP_TESTING)
     mrt_add_tests(test)
     mrt_add_nosetests(test)
 endif()

--- a/lanelet2_matching/CMakeLists.txt
+++ b/lanelet2_matching/CMakeLists.txt
@@ -3,10 +3,17 @@ set(MRT_PKG_VERSION 4.0.0)
 cmake_minimum_required(VERSION 3.5.1)
 project(lanelet2_matching)
 
+if(WIN32 AND MSVC)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 ###################
 ## Find packages ##
 ###################
 find_package(mrt_cmake_modules REQUIRED)
+if(WIN32 AND ROS_VERSION EQUAL 1)
+  set(MRT_CMAKE_ENV ${CATKIN_ENV})
+endif()
 include(UseMrtStdCompilerFlags)
 include(GatherDeps)
 

--- a/lanelet2_matching/src/Utilities.cpp
+++ b/lanelet2_matching/src/Utilities.cpp
@@ -50,7 +50,9 @@ double positiveFloatModulo(double x, double y) {
 }
 
 // from https://github.com/coincar-sim/util_eigen_geometry/blob/release/src/util_eigen_geometry.cpp
-double normalizeAngleRadians(double x) { return positiveFloatModulo((x + M_PI), 2.0 * M_PI) - M_PI; }
+double normalizeAngleRadians(double x) {
+  return positiveFloatModulo((x + lanelet::Pi), 2.0 * lanelet::Pi) - lanelet::Pi;
+}
 
 // from https://github.com/coincar-sim/util_eigen_geometry/blob/release/src/util_eigen_geometry.cpp
 double angleDifference(double targetAngle, double sourceAngle) {

--- a/lanelet2_matching/test/lanelet2_matching.cpp
+++ b/lanelet2_matching/test/lanelet2_matching.cpp
@@ -112,7 +112,7 @@ TEST_F(MatchingUtilitiesBase, absoluteHull) {  // NOLINT
   matching::Object2d obj;
 
   obj.pose.translation() = BasicPoint2d{10, 0};                         //!< at point x=10 y=0
-  obj.pose.linear() = Eigen::Rotation2D<double>(-1.5 * M_PI).matrix();  //!< rotated by pi/2 (=-3pi/2)
+  obj.pose.linear() = Eigen::Rotation2D<double>(-1.5 * Pi).matrix();  //!< rotated by pi/2 (=-3pi/2)
 
   obj.absoluteHull = absoluteHull(matching::Hull2d{BasicPoint2d{-0.5, -1}, BasicPoint2d{2, 1}}, obj.pose);
 
@@ -126,7 +126,7 @@ TEST_F(MatchingUtilitiesBase, absoluteHull) {  // NOLINT
 TEST_F(MatchingUtilitiesBase, findWithin) {  // NOLINT
   matching::Object2d obj;
   obj.pose.translation() = lanelet::BasicPoint2d(2.05, 1.);
-  obj.pose.linear() = Eigen::Rotation2D<double>(150. / 180. * M_PI).matrix();
+  obj.pose.linear() = Eigen::Rotation2D<double>(150. / 180. * Pi).matrix();
 
   EXPECT_EQ(2ul, matching::utils::findWithin(map->laneletLayer, obj, 0.1).size());
 
@@ -143,7 +143,7 @@ TEST_F(MatchingUtilitiesBase, findWithin) {  // NOLINT
 TEST_F(MatchingUtilitiesBase, getMahalanobisDistSq) {  // NOLINT
   matching::ObjectWithCovariance2d obj;
   obj.pose.translation() = lanelet::BasicPoint2d(2.05, 1.);
-  obj.pose.linear() = Eigen::Rotation2D<double>(1. / 180. * M_PI).matrix();  // one degree orientation
+  obj.pose.linear() = Eigen::Rotation2D<double>(1. / 180. * Pi).matrix();  // one degree orientation
   obj.absoluteHull = absoluteHull(
       matching::Hull2d{BasicPoint2d{-1, -0.9}, BasicPoint2d{2, -0.9}, BasicPoint2d{2, 0.9}, BasicPoint2d{1, 0.9}},
       obj.pose);
@@ -158,7 +158,7 @@ TEST_F(MatchingUtilitiesBase, getMahalanobisDistSq) {  // NOLINT
       << "should throw on determinant = zero";
 
   obj.positionCovariance = matching::PositionCovariance2d::Identity() * 2.;
-  obj.vonMisesKappa = 1. / (10. / 180. * M_PI);  // covariance of 10 degrees
+  obj.vonMisesKappa = 1. / (10. / 180. * Pi);  // covariance of 10 degrees
 
   double mahaDist21 = getMahalanobisDistSq(map->laneletLayer.get(21), obj);
   EXPECT_NEAR(0.011, mahaDist21, 10e-2);
@@ -171,12 +171,12 @@ class MatchingBase : public MatchingUtilitiesBase {
  public:
   MatchingBase() {
     obj.pose.translation() = lanelet::BasicPoint2d(1., 1.);
-    obj.pose.linear() = Eigen::Rotation2D<double>(90.1 / 180. * M_PI).matrix();
+    obj.pose.linear() = Eigen::Rotation2D<double>(90.1 / 180. * Pi).matrix();
     obj.absoluteHull = absoluteHull(
         matching::Hull2d{BasicPoint2d{-1, -0.9}, BasicPoint2d{2, -0.9}, BasicPoint2d{2, 0.9}, BasicPoint2d{1, 0.9}},
         obj.pose);
     obj.positionCovariance = matching::PositionCovariance2d::Identity() * 2.;
-    obj.vonMisesKappa = 1. / (10. / 180. * M_PI);  // covariance of 10 degrees
+    obj.vonMisesKappa = 1. / (10. / 180. * Pi);  // covariance of 10 degrees
   }
   matching::ObjectWithCovariance2d obj;
 };

--- a/lanelet2_projection/CMakeLists.txt
+++ b/lanelet2_projection/CMakeLists.txt
@@ -3,10 +3,17 @@ set(MRT_PKG_VERSION 4.0.0)
 cmake_minimum_required(VERSION 3.5.1)
 project(lanelet2_projection)
 
+if(WIN32 AND MSVC)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 ###################
 ## Find packages ##
 ###################
 find_package(mrt_cmake_modules REQUIRED)
+if(WIN32 AND ROS_VERSION EQUAL 1)
+  set(MRT_CMAKE_ENV ${CATKIN_ENV})
+endif()
 include(UseMrtStdCompilerFlags)
 include(GatherDeps)
 
@@ -51,6 +58,7 @@ mrt_add_library(${PROJECT_NAME}
     INCLUDES ${PROJECT_HEADER_FILES_INC} ${PROJECT_SOURCE_FILES_INC}
     SOURCES ${PROJECT_SOURCE_FILES_SRC}
     )
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 
 #############
 ## Install ##

--- a/lanelet2_projection/CMakeLists.txt
+++ b/lanelet2_projection/CMakeLists.txt
@@ -63,7 +63,7 @@ mrt_install(PROGRAMS scripts FILES res data ${PROJECT_INSTALL_FILES})
 ## Testing ##
 #############
 # Add test targets for cpp and python tests
-if (CATKIN_ENABLE_TESTING)
+if (CATKIN_ENABLE_TESTING AND NOT CATKIN_SKIP_TESTING)
     mrt_add_tests(test)
     mrt_add_nosetests(test)
 endif()

--- a/lanelet2_projection/include/lanelet2_projection/Mercator.h
+++ b/lanelet2_projection/include/lanelet2_projection/Mercator.h
@@ -17,25 +17,25 @@ class Mercator : public Projector {
  private:
   static BasicPoint3d rawForward(const GPSPoint& p) {
     double lat = std::min(89.5, std::max(p.lat, -89.5));
-    double phi = lat * M_PI / 180.0;
+    double phi = lat * Pi / 180.0;
     double con = Eccent * std::sin(phi);
     con = std::pow((1.0 - con) / (1.0 + con), 0.5 * Eccent);
-    double ts = std::tan(0.5 * (M_PI * 0.5 - phi)) / con;
+    double ts = std::tan(0.5 * (Pi * 0.5 - phi)) / con;
     const double y = -RMajor * std::log(ts);
-    const double x = RMajor * p.lon * M_PI / 180.;
+    const double x = RMajor * p.lon * Pi / 180.;
     return {x, y, p.ele};
   }
   static GPSPoint rawReverse(const BasicPoint3d& p) {
     double ts = std::exp(-p.y() / RMajor);
-    double phi = M_PI / 2 - 2 * std::atan(ts);
+    double phi = Pi / 2 - 2 * std::atan(ts);
     double dphi = 1.0;
     for (int i = 0; fabs(dphi) > 0.000000001 && i < 15; i++) {
       double con = Eccent * sin(phi);
-      dphi = M_PI / 2 - 2 * atan(ts * pow((1.0 - con) / (1.0 + con), 0.5 * Eccent)) - phi;
+      dphi = Pi / 2 - 2 * atan(ts * pow((1.0 - con) / (1.0 + con), 0.5 * Eccent)) - phi;
       phi += dphi;
     }
-    const double lat = 180 / M_PI * phi;
-    const double lon = 180 / M_PI * p.x() / RMajor;
+    const double lat = 180 / Pi * phi;
+    const double lon = 180 / Pi * p.x() / RMajor;
     return {lat, lon, p.z()};
   }
 

--- a/lanelet2_python/CMakeLists.txt
+++ b/lanelet2_python/CMakeLists.txt
@@ -13,6 +13,10 @@ endif()
 include(UseMrtStdCompilerFlags)
 include(GatherDeps)
 
+if(MSVC)
+  add_compile_options(/bigobj)
+endif()
+
 # You can add a custom.cmake in order to add special handling for this package. E.g. you can do:
 # list(REMOVE_ITEM DEPENDEND_PACKAGES <package name 1> <package name 2> ...)
 # To remove libs which cannot be found automatically. You can also "find_package" other, custom dependencies there.

--- a/lanelet2_python/CMakeLists.txt
+++ b/lanelet2_python/CMakeLists.txt
@@ -7,6 +7,9 @@ project(lanelet2_python)
 ## Find packages ##
 ###################
 find_package(mrt_cmake_modules REQUIRED)
+if(WIN32 AND ROS_VERSION EQUAL 1)
+  set(MRT_CMAKE_ENV ${CATKIN_ENV})
+endif()
 include(UseMrtStdCompilerFlags)
 include(GatherDeps)
 

--- a/lanelet2_python/CMakeLists.txt
+++ b/lanelet2_python/CMakeLists.txt
@@ -66,7 +66,7 @@ mrt_install(PROGRAMS scripts FILES res data ${PROJECT_INSTALL_FILES})
 ## Testing ##
 #############
 # Add test targets for cpp and python tests
-if (CATKIN_ENABLE_TESTING)
+if (CATKIN_ENABLE_TESTING AND NOT CATKIN_SKIP_TESTING)
     mrt_add_tests(test)
     mrt_add_nosetests(test)
 endif()

--- a/lanelet2_routing/CMakeLists.txt
+++ b/lanelet2_routing/CMakeLists.txt
@@ -63,7 +63,7 @@ mrt_install(PROGRAMS scripts FILES res data ${PROJECT_INSTALL_FILES})
 ## Testing ##
 #############
 # Add test targets for cpp and python tests
-if (CATKIN_ENABLE_TESTING)
+if (CATKIN_ENABLE_TESTING AND NOT CATKIN_SKIP_TESTING)
     mrt_add_tests(test)
     mrt_add_nosetests(test)
 endif()

--- a/lanelet2_routing/CMakeLists.txt
+++ b/lanelet2_routing/CMakeLists.txt
@@ -3,10 +3,17 @@ set(MRT_PKG_VERSION 4.0.0)
 cmake_minimum_required(VERSION 3.5.1)
 project(lanelet2_routing)
 
+if(WIN32 AND MSVC)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 ###################
 ## Find packages ##
 ###################
 find_package(mrt_cmake_modules REQUIRED)
+if(WIN32 AND ROS_VERSION EQUAL 1)
+  set(MRT_CMAKE_ENV ${CATKIN_ENV})
+endif()
 include(UseMrtStdCompilerFlags)
 include(GatherDeps)
 

--- a/lanelet2_routing/src/RouteBuilder.cpp
+++ b/lanelet2_routing/src/RouteBuilder.cpp
@@ -13,6 +13,10 @@ namespace lanelet {
 namespace routing {
 namespace internal {
 namespace {
+constexpr auto AllowedRouteRelation = RelationType::Successor | RelationType::Left | RelationType::Right;
+constexpr auto AdjacentRelation =
+    RelationType::Left | RelationType::Right | RelationType::AdjacentLeft | RelationType::AdjacentRight;
+
 template <typename Graph, typename StartVertex, typename Visitor>
 void breadthFirstSearch(const Graph& g, StartVertex v, Visitor vis) {
   SparseColorMap cm;
@@ -214,8 +218,7 @@ class PathsOutOfRouteFinder {
     for (auto newVertex : newConflictingVertices_) {
       auto inEdges = boost::in_edges(newVertex, g_);
       auto connectsToRoute = [&](auto e) {
-        constexpr auto AllowedRelation = RelationType::Successor | RelationType::Left | RelationType::Right;
-        return hasRelation<AllowedRelation>(g_, e) && has(*llts_, boost::source(e, g_));
+        return hasRelation<AllowedRouteRelation>(g_, e) && has(*llts_, boost::source(e, g_));
       };
       if (std::any_of(inEdges.first, inEdges.second, connectsToRoute)) {
         iterRoute_.forEachPath(newVertex, testIfPathIsPermitted);
@@ -234,12 +237,14 @@ class PathsOutOfRouteFinder {
     auto isAdjacentToRoute = [&](LaneletVertexId v) {
       auto inEdges = boost::in_edges(v, g);
       auto outEdges = boost::out_edges(v, g);
-      constexpr auto Adjacent =
-          RelationType::Left | RelationType::Right | RelationType::AdjacentLeft | RelationType::AdjacentRight;
       return std::any_of(inEdges.first, inEdges.second,
-                         [&](auto e) { return hasRelation<Adjacent>(g, e) && has(*llts_, boost::source(e, g)); }) ||
+                         [&](auto e) {
+                           return hasRelation<AdjacentRelation>(g, e) && has(*llts_, boost::source(e, g));
+                         }) ||
              std::any_of(outEdges.first, outEdges.second,
-                         [&](auto e) { return hasRelation<Adjacent>(g, e) && has(*llts_, boost::target(e, g)); });
+                         [&](auto e) {
+                           return hasRelation<AdjacentRelation>(g, e) && has(*llts_, boost::target(e, g));
+                         });
     };
     return std::all_of(path.begin(), path.end(), isAdjacentToRoute);
   }

--- a/lanelet2_traffic_rules/CMakeLists.txt
+++ b/lanelet2_traffic_rules/CMakeLists.txt
@@ -63,7 +63,7 @@ mrt_install(PROGRAMS scripts FILES res data ${PROJECT_INSTALL_FILES})
 ## Testing ##
 #############
 # Add test targets for cpp and python tests
-if (CATKIN_ENABLE_TESTING)
+if (CATKIN_ENABLE_TESTING AND NOT CATKIN_SKIP_TESTING)
     mrt_add_tests(test)
     mrt_add_nosetests(test)
 endif()

--- a/lanelet2_traffic_rules/CMakeLists.txt
+++ b/lanelet2_traffic_rules/CMakeLists.txt
@@ -3,10 +3,17 @@ set(MRT_PKG_VERSION 4.0.0)
 cmake_minimum_required(VERSION 3.5.1)
 project(lanelet2_traffic_rules)
 
+if(WIN32 AND MSVC)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 ###################
 ## Find packages ##
 ###################
 find_package(mrt_cmake_modules REQUIRED)
+if(WIN32 AND ROS_VERSION EQUAL 1)
+  set(MRT_CMAKE_ENV ${CATKIN_ENV})
+endif()
 include(UseMrtStdCompilerFlags)
 include(GatherDeps)
 

--- a/lanelet2_validation/CMakeLists.txt
+++ b/lanelet2_validation/CMakeLists.txt
@@ -75,7 +75,7 @@ mrt_install(PROGRAMS scripts FILES res data ${PROJECT_INSTALL_FILES})
 ## Testing ##
 #############
 # Add test targets for cpp and python tests
-if (CATKIN_ENABLE_TESTING)
+if (CATKIN_ENABLE_TESTING AND NOT CATKIN_SKIP_TESTING)
     mrt_add_tests(test)
     mrt_add_nosetests(test)
 endif()

--- a/lanelet2_validation/CMakeLists.txt
+++ b/lanelet2_validation/CMakeLists.txt
@@ -3,10 +3,17 @@ set(MRT_PKG_VERSION 4.0.0)
 cmake_minimum_required(VERSION 3.5.1)
 project(lanelet2_validation)
 
+if(WIN32 AND MSVC)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 ###################
 ## Find packages ##
 ###################
 find_package(mrt_cmake_modules REQUIRED)
+if(WIN32 AND ROS_VERSION EQUAL 1)
+  set(MRT_CMAKE_ENV ${CATKIN_ENV})
+endif()
 include(UseMrtStdCompilerFlags)
 include(GatherDeps)
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,14 +1,32 @@
 [workspace]
 channels = [
   "https://prefix.dev/pixi-build-backends",
-  "https://prefix.dev/robostack-jazzy",
   "https://prefix.dev/conda-forge",
 ]
 name = "lanelet2"
 platforms = ["linux-64", "osx-arm64", "win-64"]
 preview = ["pixi-build"]
 
-[dependencies]
+[feature.humble]
+channels = ["https://prefix.dev/robostack-humble"]
+
+[feature.humble.dependencies]
+ros-humble-lanelet2 = { path = "lanelet2/package.xml" }
+ros-humble-lanelet2-core = { path = "lanelet2_core/package.xml" }
+ros-humble-lanelet2-examples = { path = "lanelet2_examples/package.xml" }
+ros-humble-lanelet2-io = { path = "lanelet2_io/package.xml" }
+ros-humble-lanelet2-maps = { path = "lanelet2_maps/package.xml" }
+ros-humble-lanelet2-matching = { path = "lanelet2_matching/package.xml" }
+ros-humble-lanelet2-projection = { path = "lanelet2_projection/package.xml" }
+ros-humble-lanelet2-python = { path = "lanelet2_python/package.xml" }
+ros-humble-lanelet2-routing = { path = "lanelet2_routing/package.xml" }
+ros-humble-lanelet2-traffic-rules = { path = "lanelet2_traffic_rules/package.xml" }
+ros-humble-lanelet2-validation = { path = "lanelet2_validation/package.xml" }
+
+[feature.jazzy]
+channels = ["https://prefix.dev/robostack-jazzy"]
+
+[feature.jazzy.dependencies]
 ros-jazzy-lanelet2 = { path = "lanelet2/package.xml" }
 ros-jazzy-lanelet2-core = { path = "lanelet2_core/package.xml" }
 ros-jazzy-lanelet2-examples = { path = "lanelet2_examples/package.xml" }
@@ -20,3 +38,42 @@ ros-jazzy-lanelet2-python = { path = "lanelet2_python/package.xml" }
 ros-jazzy-lanelet2-routing = { path = "lanelet2_routing/package.xml" }
 ros-jazzy-lanelet2-traffic-rules = { path = "lanelet2_traffic_rules/package.xml" }
 ros-jazzy-lanelet2-validation = { path = "lanelet2_validation/package.xml" }
+
+[feature.kilted]
+channels = ["https://prefix.dev/robostack-kilted"]
+
+[feature.kilted.dependencies]
+ros-kilted-lanelet2 = { path = "lanelet2/package.xml" }
+ros-kilted-lanelet2-core = { path = "lanelet2_core/package.xml" }
+ros-kilted-lanelet2-examples = { path = "lanelet2_examples/package.xml" }
+ros-kilted-lanelet2-io = { path = "lanelet2_io/package.xml" }
+ros-kilted-lanelet2-maps = { path = "lanelet2_maps/package.xml" }
+ros-kilted-lanelet2-matching = { path = "lanelet2_matching/package.xml" }
+ros-kilted-lanelet2-projection = { path = "lanelet2_projection/package.xml" }
+ros-kilted-lanelet2-python = { path = "lanelet2_python/package.xml" }
+ros-kilted-lanelet2-routing = { path = "lanelet2_routing/package.xml" }
+ros-kilted-lanelet2-traffic-rules = { path = "lanelet2_traffic_rules/package.xml" }
+ros-kilted-lanelet2-validation = { path = "lanelet2_validation/package.xml" }
+
+[feature.rolling]
+channels = ["https://prefix.dev/robostack-rolling"]
+
+[feature.rolling.dependencies]
+ros-rolling-lanelet2 = { path = "lanelet2/package.xml" }
+ros-rolling-lanelet2-core = { path = "lanelet2_core/package.xml" }
+ros-rolling-lanelet2-examples = { path = "lanelet2_examples/package.xml" }
+ros-rolling-lanelet2-io = { path = "lanelet2_io/package.xml" }
+ros-rolling-lanelet2-maps = { path = "lanelet2_maps/package.xml" }
+ros-rolling-lanelet2-matching = { path = "lanelet2_matching/package.xml" }
+ros-rolling-lanelet2-projection = { path = "lanelet2_projection/package.xml" }
+ros-rolling-lanelet2-python = { path = "lanelet2_python/package.xml" }
+ros-rolling-lanelet2-routing = { path = "lanelet2_routing/package.xml" }
+ros-rolling-lanelet2-traffic-rules = { path = "lanelet2_traffic_rules/package.xml" }
+ros-rolling-lanelet2-validation = { path = "lanelet2_validation/package.xml" }
+
+[environments]
+default = { features = ["jazzy"], solve-group = "jazzy" }
+humble = ["humble"]
+jazzy = { features = ["jazzy"], solve-group = "jazzy" }
+kilted = ["kilted"]
+rolling = ["rolling"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,22 @@
+[workspace]
+channels = [
+  "https://prefix.dev/pixi-build-backends",
+  "https://prefix.dev/robostack-jazzy",
+  "https://prefix.dev/conda-forge",
+]
+name = "lanelet2"
+platforms = ["linux-64", "osx-arm64", "win-64"]
+preview = ["pixi-build"]
+
+[dependencies]
+ros-jazzy-lanelet2 = { path = "lanelet2/package.xml" }
+ros-jazzy-lanelet2-core = { path = "lanelet2_core/package.xml" }
+ros-jazzy-lanelet2-examples = { path = "lanelet2_examples/package.xml" }
+ros-jazzy-lanelet2-io = { path = "lanelet2_io/package.xml" }
+ros-jazzy-lanelet2-maps = { path = "lanelet2_maps/package.xml" }
+ros-jazzy-lanelet2-matching = { path = "lanelet2_matching/package.xml" }
+ros-jazzy-lanelet2-projection = { path = "lanelet2_projection/package.xml" }
+ros-jazzy-lanelet2-python = { path = "lanelet2_python/package.xml" }
+ros-jazzy-lanelet2-routing = { path = "lanelet2_routing/package.xml" }
+ros-jazzy-lanelet2-traffic-rules = { path = "lanelet2_traffic_rules/package.xml" }
+ros-jazzy-lanelet2-validation = { path = "lanelet2_validation/package.xml" }

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,6 +7,23 @@ name = "lanelet2"
 platforms = ["linux-64", "osx-arm64", "win-64"]
 preview = ["pixi-build"]
 
+[feature.noetic]
+channels = ["https://prefix.dev/robostack-noetic"]
+platforms = ["linux-64", "osx-arm64"]
+
+[feature.noetic.dependencies]
+ros-noetic-lanelet2 = { path = "lanelet2/package.xml" }
+ros-noetic-lanelet2-core = { path = "lanelet2_core/package.xml" }
+ros-noetic-lanelet2-examples = { path = "lanelet2_examples/package.xml" }
+ros-noetic-lanelet2-io = { path = "lanelet2_io/package.xml" }
+ros-noetic-lanelet2-maps = { path = "lanelet2_maps/package.xml" }
+ros-noetic-lanelet2-matching = { path = "lanelet2_matching/package.xml" }
+ros-noetic-lanelet2-projection = { path = "lanelet2_projection/package.xml" }
+ros-noetic-lanelet2-python = { path = "lanelet2_python/package.xml" }
+ros-noetic-lanelet2-routing = { path = "lanelet2_routing/package.xml" }
+ros-noetic-lanelet2-traffic-rules = { path = "lanelet2_traffic_rules/package.xml" }
+ros-noetic-lanelet2-validation = { path = "lanelet2_validation/package.xml" }
+
 [feature.humble]
 channels = ["https://prefix.dev/robostack-humble"]
 
@@ -73,6 +90,7 @@ ros-rolling-lanelet2-validation = { path = "lanelet2_validation/package.xml" }
 
 [environments]
 default = { features = ["jazzy"], solve-group = "jazzy" }
+noetic = ["noetic"]
 humble = ["humble"]
 jazzy = { features = ["jazzy"], solve-group = "jazzy" }
 kilted = ["kilted"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -8,8 +8,7 @@ platforms = ["linux-64", "osx-arm64", "win-64"]
 preview = ["pixi-build"]
 
 [feature.noetic]
-channels = ["https://prefix.dev/robostack-noetic"]
-platforms = ["linux-64", "osx-arm64"]
+channels = ["robostack-noetic"]
 
 [feature.noetic.dependencies]
 ros-noetic-lanelet2 = { path = "lanelet2/package.xml" }


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack patch/ros-rolling-lanelet2-core.win.patch, authored by Daisuke Nishimatsu.

MSVC is stricter around several dependent names and return-type SFINAE patterns used in lanelet2_core. This moves those constraints into template parameters, qualifies dependent helper names, fixes a dependent PrimitiveLayer type reference, and enables Windows symbol export generation so the core library builds more portably on Windows.